### PR TITLE
Feat/boards management 0518

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ __screenshots__/
 docs/ai
 
 *.db
+test.db

--- a/backend/app/routers/boards.py
+++ b/backend/app/routers/boards.py
@@ -1,18 +1,85 @@
+from uuid import UUID
+
 from fastapi import APIRouter
+from fastapi import Depends
+from fastapi import HTTPException
+from fastapi import status
+from sqlalchemy.orm import Session
+
+from app.deps.auth import require_admin
+from app.deps.db import get_db
+from app.deps.services import get_board_service
+from app.models.user import User
+from app.schemas.board import BoardCreate
+from app.schemas.board import BoardRead
+from app.schemas.board import BoardUpdate
+from app.schemas.response import ApiResponse
+from app.services.board_service import BoardService
 
 router = APIRouter(prefix="/boards", tags=["boards"])
 
 
-@router.get("/")
-async def list_boards():
-    pass
+@router.post(
+    "",
+    response_model=ApiResponse[BoardRead],
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_board(
+    payload: BoardCreate,
+    db: Session = Depends(get_db),
+    _current_user: User = Depends(require_admin),
+    service: BoardService = Depends(get_board_service),
+):
+    if service.slug_exists(db, payload.slug):
+        raise HTTPException(status_code=409, detail="Board slug already exists")
+    return ApiResponse(data=service.create(db, obj_in=payload))
 
 
-@router.post("/")
-async def create_board():
-    pass
+@router.get("", response_model=ApiResponse[list[BoardRead]])
+async def list_boards(
+    db: Session = Depends(get_db),
+    service: BoardService = Depends(get_board_service),
+):
+    return ApiResponse(data=service.get_all(db))
 
 
-@router.get("/{board_id}")
-async def get_board(board_id: str):
-    pass
+@router.get("/{id}", response_model=ApiResponse[BoardRead])
+async def get_board(
+    id: UUID,
+    db: Session = Depends(get_db),
+    service: BoardService = Depends(get_board_service),
+):
+    board = service.get_by_id(db, id)
+    if not board:
+        raise HTTPException(status_code=404, detail="Board not found")
+    return ApiResponse(data=board)
+
+
+@router.patch("/{id}", response_model=ApiResponse[BoardRead])
+async def update_board(
+    id: UUID,
+    payload: BoardUpdate,
+    db: Session = Depends(get_db),
+    _current_user: User = Depends(require_admin),
+    service: BoardService = Depends(get_board_service),
+):
+    board = service.get_by_id(db, id)
+    if not board:
+        raise HTTPException(status_code=404, detail="Board not found")
+    if payload.slug and service.slug_exists(db, payload.slug, exclude_id=id):
+        raise HTTPException(status_code=409, detail="Board slug already exists")
+    return ApiResponse(data=service.update(db, db_obj=board, obj_in=payload))
+
+
+@router.delete("/{id}", response_model=ApiResponse)
+async def delete_board(
+    id: UUID,
+    db: Session = Depends(get_db),
+    _current_user: User = Depends(require_admin),
+    service: BoardService = Depends(get_board_service),
+):
+    board = service.get_by_id(db, id)
+    if not board:
+        raise HTTPException(status_code=404, detail="Board not found")
+    service.remove(db, db_obj=board)
+    return ApiResponse(message="Board deleted")

--- a/backend/app/services/board_service.py
+++ b/backend/app/services/board_service.py
@@ -29,6 +29,14 @@ class BoardService:
             .first()
         )
 
+    def slug_exists(
+        self, db: Session, slug: str, *, exclude_id: UUID | None = None
+    ) -> bool:
+        query = db.query(Board).filter(Board.slug == slug)
+        if exclude_id is not None:
+            query = query.filter(Board.id != exclude_id)
+        return query.first() is not None
+
     def create(self, db: Session, *, obj_in: BoardCreate) -> Board:
         db_obj = Board(**obj_in.model_dump())
         db.add(db_obj)

--- a/backend/tests/test_boards.py
+++ b/backend/tests/test_boards.py
@@ -1,0 +1,186 @@
+"""
+Boards 路由集成测试：公开查询、admin 管理、软删除。
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.database import get_db
+from app.main import app
+from app.models.base import Base
+
+SQLALCHEMY_DATABASE_URL = "sqlite:///test.db"
+
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
+)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+@pytest.fixture(autouse=True)
+def _setup_db():
+    Base.metadata.create_all(bind=engine)
+    yield
+    Base.metadata.drop_all(bind=engine)
+
+
+def _override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@pytest.fixture()
+def client():
+    app.dependency_overrides[get_db] = _override_get_db
+    c = TestClient(app)
+    yield c
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture()
+def db_session():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+AUTH_PREFIX = "/api/v1/auth"
+API_PREFIX = "/api/v1/boards"
+
+
+def _register_and_login(
+    client, username="boarduser", email="boarduser@example.com"
+) -> tuple[str, str]:
+    client.post(
+        f"{AUTH_PREFIX}/register",
+        json={
+            "username": username,
+            "email": email,
+            "password": "securepass123",
+        },
+    )
+    login_resp = client.post(
+        f"{AUTH_PREFIX}/login",
+        json={"account": username, "password": "securepass123"},
+    )
+    data = login_resp.json()["data"]
+    return data["access_token"], data["user"]["id"]
+
+
+def _register_and_login_admin(
+    client, db_session, username="boardadmin", email="boardadmin@example.com"
+) -> tuple[str, str]:
+    token, user_id = _register_and_login(client, username, email)
+
+    from uuid import UUID
+
+    from app.models.user import User
+
+    user = db_session.query(User).filter(User.id == UUID(user_id)).first()
+    user.role = "admin"
+    db_session.add(user)
+    db_session.commit()
+    return token, user_id
+
+
+def _create_board(client, token, name="General", slug="general", sort_order=10):
+    return client.post(
+        API_PREFIX,
+        json={
+            "name": name,
+            "slug": slug,
+            "description": f"{name} board",
+            "sort_order": sort_order,
+        },
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+
+def test_list_boards_orders_by_sort_order(client, db_session):
+    token, _ = _register_and_login_admin(client, db_session)
+    _create_board(client, token, name="Later", slug="later", sort_order=20)
+    _create_board(client, token, name="First", slug="first", sort_order=1)
+    _create_board(client, token, name="Middle", slug="middle", sort_order=10)
+
+    resp = client.get(API_PREFIX)
+
+    assert resp.status_code == 200
+    items = resp.json()["data"]
+    assert [item["slug"] for item in items] == ["first", "middle", "later"]
+
+
+def test_get_board_detail(client, db_session):
+    token, _ = _register_and_login_admin(client, db_session)
+    create_resp = _create_board(client, token)
+    board_id = create_resp.json()["data"]["id"]
+
+    resp = client.get(f"{API_PREFIX}/{board_id}")
+
+    assert resp.status_code == 200
+    assert resp.json()["data"]["id"] == board_id
+    assert resp.json()["data"]["slug"] == "general"
+
+
+def test_non_admin_cannot_create_update_or_delete_board(client, db_session):
+    admin_token, _ = _register_and_login_admin(client, db_session)
+    user_token, _ = _register_and_login(
+        client, username="normaluser", email="normal@example.com"
+    )
+    board_id = _create_board(client, admin_token).json()["data"]["id"]
+    headers = {"Authorization": f"Bearer {user_token}"}
+
+    create_resp = client.post(
+        API_PREFIX,
+        json={"name": "User Board", "slug": "user-board", "sort_order": 1},
+        headers=headers,
+    )
+    update_resp = client.patch(
+        f"{API_PREFIX}/{board_id}",
+        json={"name": "Blocked"},
+        headers=headers,
+    )
+    delete_resp = client.delete(f"{API_PREFIX}/{board_id}", headers=headers)
+
+    assert create_resp.status_code == 403
+    assert update_resp.status_code == 403
+    assert delete_resp.status_code == 403
+
+
+def test_admin_can_update_board(client, db_session):
+    token, _ = _register_and_login_admin(client, db_session)
+    board_id = _create_board(client, token).json()["data"]["id"]
+
+    resp = client.patch(
+        f"{API_PREFIX}/{board_id}",
+        json={"name": "Campus Life", "sort_order": 2},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert data["name"] == "Campus Life"
+    assert data["sort_order"] == 2
+
+
+def test_deleted_board_is_hidden_from_list(client, db_session):
+    token, _ = _register_and_login_admin(client, db_session)
+    board_id = _create_board(client, token).json()["data"]["id"]
+
+    delete_resp = client.delete(
+        f"{API_PREFIX}/{board_id}",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    list_resp = client.get(API_PREFIX)
+    detail_resp = client.get(f"{API_PREFIX}/{board_id}")
+
+    assert delete_resp.status_code == 200
+    assert list_resp.status_code == 200
+    assert list_resp.json()["data"] == []
+    assert detail_resp.status_code == 404

--- a/backend/tests/test_boards.py
+++ b/backend/tests/test_boards.py
@@ -2,14 +2,18 @@
 Boards 路由集成测试：公开查询、admin 管理、软删除。
 """
 
+from unittest.mock import Mock
+
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from app.database import get_db
+from app.deps import get_email_service
 from app.main import app
 from app.models.base import Base
+from app.services.email_service import EmailService
 
 SQLALCHEMY_DATABASE_URL = "sqlite:///test.db"
 
@@ -34,9 +38,28 @@ def _override_get_db():
         db.close()
 
 
+def _make_mock_email_service() -> EmailService:
+    import app.services.email_service as mod
+
+    svc = EmailService()
+    svc.send_verification_email = Mock()
+    svc.generate_verify_token = mod.EmailService.generate_verify_token.__get__(
+        svc, EmailService
+    )
+    svc.decode_verify_token = mod.EmailService.decode_verify_token.__get__(
+        svc, EmailService
+    )
+    return svc
+
+
+def _override_get_email_service():
+    return _make_mock_email_service()
+
+
 @pytest.fixture()
 def client():
     app.dependency_overrides[get_db] = _override_get_db
+    app.dependency_overrides[get_email_service] = _override_get_email_service
     c = TestClient(app)
     yield c
     app.dependency_overrides.clear()
@@ -56,7 +79,7 @@ API_PREFIX = "/api/v1/boards"
 
 
 def _register_and_login(
-    client, username="boarduser", email="boarduser@example.com"
+    client, db_session, username="boarduser", email="boarduser@example.com"
 ) -> tuple[str, str]:
     client.post(
         f"{AUTH_PREFIX}/register",
@@ -66,6 +89,14 @@ def _register_and_login(
             "password": "securepass123",
         },
     )
+
+    from app.models.user import User
+
+    user = db_session.query(User).filter(User.username == username).first()
+    user.email_verified = True
+    db_session.add(user)
+    db_session.commit()
+
     login_resp = client.post(
         f"{AUTH_PREFIX}/login",
         json={"account": username, "password": "securepass123"},
@@ -77,7 +108,7 @@ def _register_and_login(
 def _register_and_login_admin(
     client, db_session, username="boardadmin", email="boardadmin@example.com"
 ) -> tuple[str, str]:
-    token, user_id = _register_and_login(client, username, email)
+    token, user_id = _register_and_login(client, db_session, username, email)
 
     from uuid import UUID
 
@@ -131,7 +162,7 @@ def test_get_board_detail(client, db_session):
 def test_non_admin_cannot_create_update_or_delete_board(client, db_session):
     admin_token, _ = _register_and_login_admin(client, db_session)
     user_token, _ = _register_and_login(
-        client, username="normaluser", email="normal@example.com"
+        client, db_session, username="normaluser", email="normal@example.com"
     )
     board_id = _create_board(client, admin_token).json()["data"]["id"]
     headers = {"Authorization": f"Bearer {user_token}"}


### PR DESCRIPTION
  Closes #4 

  Implemented board management.

  Includes:
  - sort_order-based board listing
  - admin-only create/update/delete
  - soft delete filtering
  - integration tests for board routes
