### PR TITLE
feat(search): implement post search subsystem

### DIFF
--- a/backend/app/deps/services.py
+++ b/backend/app/deps/services.py
@@ -9,6 +9,7 @@ from app.services.notification_service import NotificationService
 from app.services.like_service import LikeService
 from app.services.comment_service import CommentService
 from app.services.media_service import MediaService
+from app.services.search_service import SearchService
 from app.storage.factory import get_storage_backend
 
 
@@ -22,6 +23,10 @@ def get_user_service() -> UserService:
 
 def get_post_service() -> PostService:
     return PostService()
+
+
+def get_search_service() -> SearchService:
+    return SearchService()
 
 
 def get_board_service() -> BoardService:
@@ -54,6 +59,7 @@ __all__ = [
     "get_auth_service",
     "get_user_service",
     "get_post_service",
+    "get_search_service",
     "get_board_service",
     "get_email_service",
     "get_notification_service",

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -24,6 +24,7 @@ from app.routers import likes
 from app.routers import media
 from app.routers import notifications
 from app.routers import posts
+from app.routers import search
 from app.routers import users
 
 settings = get_settings()
@@ -53,6 +54,7 @@ app.include_router(auth.router, prefix=settings.API_PREFIX)
 app.include_router(users.router, prefix=settings.API_PREFIX)
 app.include_router(boards.router, prefix=settings.API_PREFIX)
 app.include_router(posts.router, prefix=settings.API_PREFIX)
+app.include_router(search.router, prefix=settings.API_PREFIX)
 app.include_router(comments.router, prefix=settings.API_PREFIX)
 app.include_router(likes.router, prefix=settings.API_PREFIX)
 app.include_router(notifications.router, prefix=settings.API_PREFIX)

--- a/backend/app/models/post.py
+++ b/backend/app/models/post.py
@@ -9,7 +9,9 @@ if TYPE_CHECKING:
 from uuid import UUID
 
 from sqlalchemy import BigInteger, String, Text, Boolean, ForeignKey, DateTime
+from sqlalchemy.dialects.postgresql import TSVECTOR
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.types import TypeDecorator
 
 from app.models.base import Base, IDMixin, TimestampMixin
 
@@ -20,11 +22,23 @@ class PostStatus(str, enum.Enum):
     DELETED = "deleted"
 
 
+class SearchVectorType(TypeDecorator):
+    impl = Text
+    cache_ok = True
+
+    def load_dialect_impl(self, dialect):
+        if dialect.name == "postgresql":
+            return dialect.type_descriptor(TSVECTOR())
+        return dialect.type_descriptor(Text())
+
+
 class Post(Base, IDMixin, TimestampMixin):
     __tablename__ = "posts"
 
     title: Mapped[str] = mapped_column(String(255), nullable=False)
     content: Mapped[str] = mapped_column(Text, nullable=False)
+    search_document: Mapped[str] = mapped_column(Text, default="", nullable=False)
+    search_vector: Mapped[str | None] = mapped_column(SearchVectorType(), nullable=True)
 
     author_id: Mapped[UUID] = mapped_column(ForeignKey("users.id"), nullable=False)
     board_id: Mapped[UUID] = mapped_column(ForeignKey("boards.id"), nullable=False)

--- a/backend/app/routers/search.py
+++ b/backend/app/routers/search.py
@@ -1,0 +1,55 @@
+from datetime import date
+from typing import Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+
+from app.deps.db import get_db
+from app.deps.services import get_search_service
+from app.schemas.post import PostRead
+from app.schemas.response import PaginatedData, PaginatedResponse, PaginationInfo
+from app.schemas.search import SearchSort
+from app.services.search_service import SearchService
+
+router = APIRouter(prefix="/search", tags=["Search"])
+
+
+@router.get("/posts", response_model=PaginatedResponse[PostRead])
+def search_posts(
+    q: str = Query(..., min_length=1, max_length=100, description="搜索关键词"),
+    board_id: Optional[UUID] = Query(None, description="限定板块 ID"),
+    start_date: Optional[date] = Query(None, description="起始发布日期"),
+    end_date: Optional[date] = Query(None, description="结束发布日期"),
+    sort_by: SearchSort = Query(SearchSort.RELEVANCE, description="排序方式"),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(20, ge=1, le=100),
+    db: Session = Depends(get_db),
+    service: SearchService = Depends(get_search_service),
+):
+    if start_date and end_date and start_date > end_date:
+        raise HTTPException(
+            status_code=400, detail="start_date must be before end_date"
+        )
+
+    items, total = service.search_posts(
+        db,
+        keyword=q,
+        board_id=board_id,
+        start_date=start_date,
+        end_date=end_date,
+        sort_by=sort_by,
+        page=page,
+        page_size=page_size,
+    )
+    return PaginatedResponse(
+        data=PaginatedData(
+            items=items,
+            pagination=PaginationInfo(
+                page=page,
+                page_size=page_size,
+                total=total,
+                total_pages=(total + page_size - 1) // page_size,
+            ),
+        )
+    )

--- a/backend/app/schemas/search.py
+++ b/backend/app/schemas/search.py
@@ -1,0 +1,8 @@
+import enum
+
+
+class SearchSort(str, enum.Enum):
+    RELEVANCE = "relevance"
+    HOT = "hot"
+    TIME = "time"
+

--- a/backend/app/services/post_service.py
+++ b/backend/app/services/post_service.py
@@ -6,6 +6,7 @@ from sqlalchemy.orm import Session, joinedload
 
 from app.models.post import Post, PostStatus
 from app.schemas.post import PostCreate, PostUpdate
+from app.utils.search import build_search_document
 
 
 class PostService:
@@ -13,7 +14,8 @@ class PostService:
         db_obj = Post(
             **obj_in.model_dump(),
             author_id=author_id,
-            published_at=datetime.now(timezone.utc)
+            search_document=build_search_document(obj_in.title, obj_in.content),
+            published_at=datetime.now(timezone.utc),
         )
         db.add(db_obj)
         try:
@@ -62,6 +64,11 @@ class PostService:
         update_data = obj_in.model_dump(exclude_unset=True)
         for field, value in update_data.items():
             setattr(db_obj, field, value)
+
+        if "title" in update_data or "content" in update_data:
+            db_obj.search_document = build_search_document(
+                db_obj.title, db_obj.content
+            )
 
         db_obj.updated_at = datetime.now(timezone.utc)
         try:

--- a/backend/app/services/search_service.py
+++ b/backend/app/services/search_service.py
@@ -1,0 +1,150 @@
+from datetime import date, datetime, time, timezone
+from typing import Optional
+from uuid import UUID
+
+from sqlalchemy import desc, func, literal_column, or_
+from sqlalchemy.orm import Session, joinedload
+
+from app.models.post import Post, PostStatus
+from app.schemas.search import SearchSort
+from app.utils.search import tokenize_for_search
+
+
+class SearchService:
+    def search_posts(
+        self,
+        db: Session,
+        *,
+        keyword: str,
+        board_id: Optional[UUID] = None,
+        start_date: Optional[date] = None,
+        end_date: Optional[date] = None,
+        sort_by: SearchSort = SearchSort.RELEVANCE,
+        page: int = 1,
+        page_size: int = 20,
+    ) -> tuple[list[Post], int]:
+        tokens = tokenize_for_search(keyword)
+        if not tokens:
+            return [], 0
+
+        if db.bind and db.bind.dialect.name == "postgresql":
+            return self._search_postgresql(
+                db,
+                query_text=" ".join(tokens),
+                board_id=board_id,
+                start_date=start_date,
+                end_date=end_date,
+                sort_by=sort_by,
+                page=page,
+                page_size=page_size,
+            )
+
+        return self._search_fallback(
+            db,
+            tokens=tokens,
+            board_id=board_id,
+            start_date=start_date,
+            end_date=end_date,
+            sort_by=sort_by,
+            page=page,
+            page_size=page_size,
+        )
+
+    def _base_query(
+        self,
+        db: Session,
+        *,
+        board_id: Optional[UUID],
+        start_date: Optional[date],
+        end_date: Optional[date],
+    ):
+        query = (
+            db.query(Post)
+            .options(joinedload(Post.author))
+            .filter(
+                Post.deleted_at.is_(None),
+                Post.status == PostStatus.NORMAL.value,
+            )
+        )
+
+        if board_id:
+            query = query.filter(Post.board_id == board_id)
+        if start_date:
+            start_at = datetime.combine(start_date, time.min, tzinfo=timezone.utc)
+            query = query.filter(Post.published_at >= start_at)
+        if end_date:
+            end_at = datetime.combine(end_date, time.max, tzinfo=timezone.utc)
+            query = query.filter(Post.published_at <= end_at)
+        return query
+
+    def _apply_sorting(self, query, *, sort_by: SearchSort, rank=None):
+        hot_score = (Post.like_count * 2) + (Post.comment_count * 3)
+        if sort_by == SearchSort.HOT:
+            return query.order_by(desc(hot_score), desc(Post.published_at))
+        if sort_by == SearchSort.TIME:
+            return query.order_by(desc(Post.published_at), desc(Post.created_at))
+        if rank is not None:
+            return query.order_by(desc(rank), desc(hot_score), desc(Post.published_at))
+        return query.order_by(desc(Post.published_at), desc(Post.created_at))
+
+    def _search_postgresql(
+        self,
+        db: Session,
+        *,
+        query_text: str,
+        board_id: Optional[UUID],
+        start_date: Optional[date],
+        end_date: Optional[date],
+        sort_by: SearchSort,
+        page: int,
+        page_size: int,
+    ) -> tuple[list[Post], int]:
+        tsquery = func.websearch_to_tsquery(literal_column("'simple'"), query_text)
+        search_vector = literal_column("posts.search_vector")
+        rank = func.ts_rank_cd(search_vector, tsquery)
+
+        query = self._base_query(
+            db, board_id=board_id, start_date=start_date, end_date=end_date
+        ).filter(search_vector.op("@@")(tsquery))
+        total = query.count()
+        items = (
+            self._apply_sorting(query, sort_by=sort_by, rank=rank)
+            .offset((page - 1) * page_size)
+            .limit(page_size)
+            .all()
+        )
+        return items, total
+
+    def _search_fallback(
+        self,
+        db: Session,
+        *,
+        tokens: list[str],
+        board_id: Optional[UUID],
+        start_date: Optional[date],
+        end_date: Optional[date],
+        sort_by: SearchSort,
+        page: int,
+        page_size: int,
+    ) -> tuple[list[Post], int]:
+        query = self._base_query(
+            db, board_id=board_id, start_date=start_date, end_date=end_date
+        )
+        for token in tokens:
+            pattern = f"%{token}%"
+            query = query.filter(
+                or_(
+                    Post.title.ilike(pattern),
+                    Post.content.ilike(pattern),
+                    Post.search_document.ilike(pattern),
+                )
+            )
+
+        total = query.count()
+        items = (
+            self._apply_sorting(query, sort_by=sort_by)
+            .offset((page - 1) * page_size)
+            .limit(page_size)
+            .all()
+        )
+        return items, total

--- a/backend/app/utils/search.py
+++ b/backend/app/utils/search.py
@@ -1,0 +1,57 @@
+import logging
+import re
+
+try:
+    import jieba
+except ImportError:  # pragma: no cover - exercised only in minimal local envs
+    jieba = None
+
+if jieba is not None:
+    jieba.setLogLevel(logging.WARNING)
+
+_WHITESPACE_RE = re.compile(r"\s+")
+_ASCII_RE = re.compile(r"[a-zA-Z0-9_]+")
+_CJK_RE = re.compile(r"[\u4e00-\u9fff]+")
+
+
+def _fallback_tokens(text: str) -> list[str]:
+    tokens: list[str] = []
+    for match in re.finditer(r"[a-zA-Z0-9_]+|[\u4e00-\u9fff]+", text):
+        value = match.group(0).lower()
+        if _ASCII_RE.fullmatch(value):
+            tokens.append(value)
+            continue
+
+        if _CJK_RE.fullmatch(value):
+            tokens.append(value)
+            if len(value) > 1:
+                tokens.extend(value[i : i + 2] for i in range(len(value) - 1))
+    return tokens
+
+
+def tokenize_for_search(text: str) -> list[str]:
+    """Tokenize Chinese and mixed-language text for PostgreSQL simple tsvector."""
+    normalized = _WHITESPACE_RE.sub(" ", text.strip())
+    if not normalized:
+        return []
+
+    raw_tokens = (
+        jieba.cut_for_search(normalized)
+        if jieba is not None
+        else _fallback_tokens(normalized)
+    )
+
+    tokens: list[str] = []
+    seen: set[str] = set()
+    for token in raw_tokens:
+        word = token.strip().lower()
+        if not word or word in seen:
+            continue
+        seen.add(word)
+        tokens.append(word)
+    return tokens
+
+
+def build_search_document(*parts: str | None) -> str:
+    text = " ".join(part for part in parts if part)
+    return " ".join(tokenize_for_search(text))

--- a/backend/migrations/versions/5f6a7b8c9d10_add_post_search_index.py
+++ b/backend/migrations/versions/5f6a7b8c9d10_add_post_search_index.py
@@ -1,0 +1,81 @@
+"""add_post_search_index
+
+Revision ID: 5f6a7b8c9d10
+Revises: c12e790a4df5
+Create Date: 2026-06-06 15:30:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "5f6a7b8c9d10"
+down_revision: Union[str, Sequence[str], None] = "c12e790a4df5"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "posts",
+        sa.Column("search_document", sa.Text(), nullable=False, server_default=""),
+    )
+    op.add_column(
+        "posts",
+        sa.Column("search_vector", postgresql.TSVECTOR(), nullable=True),
+    )
+
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION posts_search_vector_refresh()
+        RETURNS trigger AS $$
+        BEGIN
+            NEW.search_vector :=
+                to_tsvector('simple', COALESCE(NEW.search_document, ''));
+            RETURN NEW;
+        END
+        $$ LANGUAGE plpgsql;
+        """
+    )
+    op.execute(
+        """
+        CREATE TRIGGER trg_posts_search_vector_refresh
+        BEFORE INSERT OR UPDATE OF search_document ON posts
+        FOR EACH ROW EXECUTE FUNCTION posts_search_vector_refresh();
+        """
+    )
+    op.execute(
+        """
+        UPDATE posts
+        SET search_document =
+            COALESCE(title, '') || ' ' || COALESCE(content, '')
+        """
+    )
+
+    op.create_index(
+        "ix_posts_search_vector",
+        "posts",
+        ["search_vector"],
+        postgresql_using="gin",
+        postgresql_where=sa.text("deleted_at IS NULL AND status = 'normal'"),
+    )
+    op.create_index(
+        "ix_posts_search_filters",
+        "posts",
+        ["board_id", "published_at"],
+    )
+    op.alter_column("posts", "search_document", server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_posts_search_filters", table_name="posts")
+    op.drop_index("ix_posts_search_vector", table_name="posts")
+    op.execute("DROP TRIGGER IF EXISTS trg_posts_search_vector_refresh ON posts")
+    op.execute("DROP FUNCTION IF EXISTS posts_search_vector_refresh")
+    op.drop_column("posts", "search_vector")
+    op.drop_column("posts", "search_document")
+

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "boto3>=1.37.0",
     "email-validator>=2.2.0",
     "fastapi>=0.135.3",
+    "jieba>=0.42.1",
     "pydantic-settings>=2.7.1",
     "psycopg2-binary>=2.9.11",
     "pwdlib[argon2]>=0.3.0",

--- a/backend/tests/test_search.py
+++ b/backend/tests/test_search.py
@@ -1,0 +1,265 @@
+"""
+Search 路由集成测试：关键词、板块/时间筛选、排序与隐藏帖子过滤。
+
+测试使用 SQLite 回退搜索逻辑，生产 PostgreSQL 走 tsvector + GIN 索引。
+"""
+
+from datetime import datetime, timezone
+from uuid import UUID
+
+import pytest
+import pytest_asyncio
+from fastapi import status
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.database import get_db
+from app.main import app
+from app.models.base import Base
+from app.models.board import Board
+from app.models.post import Post
+from app.models.user import User
+from app.utils.security import hash_password
+
+SQLALCHEMY_DATABASE_URL = "sqlite:///test_search.db"
+
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
+)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+API_PREFIX = "/api/v1"
+AUTH_PREFIX = f"{API_PREFIX}/auth"
+POSTS_URL = f"{API_PREFIX}/posts/"
+SEARCH_URL = f"{API_PREFIX}/search/posts"
+
+
+@pytest.fixture(autouse=True)
+def _setup_db():
+    Base.metadata.create_all(bind=engine)
+    yield
+    Base.metadata.drop_all(bind=engine)
+
+
+def _override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@pytest.fixture()
+def db_session():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@pytest_asyncio.fixture()
+async def client():
+    app.dependency_overrides[get_db] = _override_get_db
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+    app.dependency_overrides.clear()
+
+
+def _create_user(db, username: str = "searcher") -> User:
+    user = User(
+        username=username,
+        email=f"{username}@test.com",
+        password_hash=hash_password("securepass123"),
+        nickname=username,
+        role="user",
+        status="active",
+        email_verified=True,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def _create_board(db, name: str, slug: str) -> Board:
+    board = Board(name=name, slug=slug, description="test", sort_order=1)
+    db.add(board)
+    db.commit()
+    db.refresh(board)
+    return board
+
+
+async def _login(client: AsyncClient, username: str) -> str:
+    resp = await client.post(
+        f"{AUTH_PREFIX}/login",
+        json={"account": username, "password": "securepass123"},
+    )
+    return resp.json()["data"]["access_token"]
+
+
+def _auth_client(token: str) -> AsyncClient:
+    transport = ASGITransport(app=app)
+    return AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+
+async def _create_post(
+    client: AsyncClient,
+    db,
+    *,
+    title: str,
+    content: str,
+    board: Board,
+    username: str = "searcher",
+):
+    if not db.query(User).filter(User.username == username).first():
+        _create_user(db, username)
+    token = await _login(client, username)
+    async with _auth_client(token) as ac:
+        resp = await ac.post(
+            POSTS_URL,
+            json={"title": title, "content": content, "board_id": str(board.id)},
+        )
+    assert resp.status_code == status.HTTP_201_CREATED
+    post_id = resp.json()["data"]["id"]
+    return db.query(Post).filter(Post.id == UUID(post_id)).first()
+
+
+@pytest.mark.asyncio
+async def test_search_posts_matches_chinese_keyword(client: AsyncClient, db_session):
+    board = _create_board(db_session, "校园生活", "life")
+    await _create_post(
+        client,
+        db_session,
+        title="食堂午饭推荐",
+        content="今天学校食堂的番茄牛腩很好吃",
+        board=board,
+    )
+    await _create_post(
+        client,
+        db_session,
+        title="课程安排",
+        content="软件工程课程下周提交作业",
+        board=board,
+    )
+
+    resp = await client.get(SEARCH_URL, params={"q": "食堂"})
+    assert resp.status_code == status.HTTP_200_OK
+    items = resp.json()["data"]["items"]
+    assert len(items) == 1
+    assert items[0]["title"] == "食堂午饭推荐"
+
+
+@pytest.mark.asyncio
+async def test_search_posts_filters_by_board(client: AsyncClient, db_session):
+    board_a = _create_board(db_session, "失物招领", "lost")
+    board_b = _create_board(db_session, "二手交易", "market")
+    await _create_post(
+        client,
+        db_session,
+        title="校园卡搜索测试",
+        content="在图书馆捡到校园卡",
+        board=board_a,
+    )
+    await _create_post(
+        client,
+        db_session,
+        title="校园卡卡套转让",
+        content="出售一个校园卡保护套",
+        board=board_b,
+    )
+
+    resp = await client.get(
+        SEARCH_URL, params={"q": "校园卡", "board_id": str(board_a.id)}
+    )
+    items = resp.json()["data"]["items"]
+    assert len(items) == 1
+    assert items[0]["board_id"] == str(board_a.id)
+
+
+@pytest.mark.asyncio
+async def test_search_posts_filters_by_date(client: AsyncClient, db_session):
+    board = _create_board(db_session, "活动", "events")
+    old_post = await _create_post(
+        client,
+        db_session,
+        title="社团活动报名",
+        content="活动搜索测试",
+        board=board,
+    )
+    new_post = await _create_post(
+        client,
+        db_session,
+        title="学院活动报名",
+        content="活动搜索测试",
+        board=board,
+    )
+    old_post.published_at = datetime(2026, 5, 20, tzinfo=timezone.utc)
+    new_post.published_at = datetime(2026, 6, 3, tzinfo=timezone.utc)
+    db_session.commit()
+
+    resp = await client.get(
+        SEARCH_URL,
+        params={"q": "活动", "start_date": "2026-06-01", "end_date": "2026-06-05"},
+    )
+    items = resp.json()["data"]["items"]
+    assert len(items) == 1
+    assert items[0]["title"] == "学院活动报名"
+
+
+@pytest.mark.asyncio
+async def test_search_posts_sorts_by_hot(client: AsyncClient, db_session):
+    board = _create_board(db_session, "讨论", "discuss")
+    low = await _create_post(
+        client,
+        db_session,
+        title="搜索排序低热度",
+        content="搜索排序测试",
+        board=board,
+    )
+    high = await _create_post(
+        client,
+        db_session,
+        title="搜索排序高热度",
+        content="搜索排序测试",
+        board=board,
+    )
+    low.like_count = 1
+    high.comment_count = 5
+    db_session.commit()
+
+    resp = await client.get(SEARCH_URL, params={"q": "搜索排序", "sort_by": "hot"})
+    items = resp.json()["data"]["items"]
+    assert items[0]["title"] == "搜索排序高热度"
+
+
+@pytest.mark.asyncio
+async def test_search_posts_excludes_hidden_posts(client: AsyncClient, db_session):
+    board = _create_board(db_session, "公告", "notice")
+    post = await _create_post(
+        client,
+        db_session,
+        title="隐藏搜索结果",
+        content="隐藏搜索测试",
+        board=board,
+    )
+    post.status = "hidden"
+    db_session.commit()
+
+    resp = await client.get(SEARCH_URL, params={"q": "隐藏搜索"})
+    assert resp.json()["data"]["items"] == []
+
+
+@pytest.mark.asyncio
+async def test_search_posts_rejects_invalid_date_range(client: AsyncClient):
+    resp = await client.get(
+        SEARCH_URL,
+        params={"q": "活动", "start_date": "2026-06-05", "end_date": "2026-06-01"},
+    )
+    assert resp.status_code == status.HTTP_400_BAD_REQUEST

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -98,6 +98,7 @@ dependencies = [
     { name = "boto3" },
     { name = "email-validator" },
     { name = "fastapi" },
+    { name = "jieba" },
     { name = "psycopg2-binary" },
     { name = "pwdlib", extra = ["argon2"] },
     { name = "pydantic" },
@@ -124,6 +125,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.37.0" },
     { name = "email-validator", specifier = ">=2.2.0" },
     { name = "fastapi", specifier = ">=0.135.3" },
+    { name = "jieba", specifier = ">=0.42.1" },
     { name = "psycopg2-binary", specifier = ">=2.9.11" },
     { name = "pwdlib", extras = ["argon2"], specifier = ">=0.3.0" },
     { name = "pydantic", specifier = ">=2.12.5" },
@@ -406,6 +408,12 @@ sdist = { url = "https://mirrors.aliyun.com/pypi/packages/72/34/14ca021ce8e5dfed
 wheels = [
     { url = "https://mirrors.aliyun.com/pypi/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12" },
 ]
+
+[[package]]
+name = "jieba"
+version = "0.42.1"
+source = { registry = "https://mirrors.aliyun.com/pypi/simple/" }
+sdist = { url = "https://mirrors.aliyun.com/pypi/packages/c6/cb/18eeb235f833b726522d7ebed54f2278ce28ba9438e3135ab0278d9792a2/jieba-0.42.1.tar.gz", hash = "sha256:055ca12f62674fafed09427f176506079bc135638a14e23e25be909131928db2" }
 
 [[package]]
 name = "jmespath"

--- a/frontend/components.d.ts
+++ b/frontend/components.d.ts
@@ -25,6 +25,7 @@ declare module 'vue' {
     ElBreadcrumb: typeof import('element-plus/es')['ElBreadcrumb']
     ElBreadcrumbItem: typeof import('element-plus/es')['ElBreadcrumbItem']
     ElButton: typeof import('element-plus/es')['ElButton']
+    ElDatePicker: typeof import('element-plus/es')['ElDatePicker']
     ElDialog: typeof import('element-plus/es')['ElDialog']
     ElDivider: typeof import('element-plus/es')['ElDivider']
     ElDropdown: typeof import('element-plus/es')['ElDropdown']

--- a/frontend/src/api/search.ts
+++ b/frontend/src/api/search.ts
@@ -1,0 +1,22 @@
+import httpClient from './client'
+import type { PaginatedData } from '@/types/api'
+import type { PostRead } from '@/types/post'
+
+export type SearchSort = 'relevance' | 'hot' | 'time'
+
+export interface SearchPostsParams {
+  q: string
+  board_id?: string
+  start_date?: string
+  end_date?: string
+  sort_by?: SearchSort
+  page?: number
+  page_size?: number
+}
+
+export const searchAPI = {
+  searchPosts(params: SearchPostsParams): Promise<PaginatedData<PostRead>> {
+    return httpClient.get('/api/v1/search/posts', { params })
+  },
+}
+

--- a/frontend/src/components/common/AppHeader.vue
+++ b/frontend/src/components/common/AppHeader.vue
@@ -6,6 +6,20 @@
         <span class="logo-text">校园论坛</span>
       </router-link>
     </div>
+    <div class="header-center">
+      <el-input
+        v-model="searchKeyword"
+        class="header-search"
+        size="small"
+        clearable
+        placeholder="搜索帖子"
+        @keyup.enter="handleSearch"
+      >
+        <template #prefix>
+          <el-icon><Search /></el-icon>
+        </template>
+      </el-input>
+    </div>
     <div class="header-right">
       <template v-if="authStore.isAuthenticated">
         <NotificationBell />
@@ -46,19 +60,51 @@
 </template>
 
 <script setup lang="ts">
-import { ChatDotRound, User, Bell, Setting, SwitchButton } from '@element-plus/icons-vue'
+import { ref, watch } from 'vue'
+import {
+  Bell,
+  ChatDotRound,
+  Search,
+  Setting,
+  SwitchButton,
+  User,
+} from '@element-plus/icons-vue'
 import { useAuthStore } from '@/stores/auth'
-import { useRouter } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import NotificationBell from '@/components/notification/NotificationBell.vue'
 import UserAvatar from '@/components/common/UserAvatar.vue'
 
 const authStore = useAuthStore()
 const router = useRouter()
+const route = useRoute()
+const searchKeyword = ref('')
 
 async function handleLogout() {
   await authStore.logout()
   router.push('/')
 }
+
+function routeQueryValue(value: unknown): string {
+  if (Array.isArray(value)) return String(value[0] || '')
+  return value ? String(value) : ''
+}
+
+function handleSearch() {
+  const q = searchKeyword.value.trim()
+  if (!q) {
+    router.push({ name: 'Search' })
+    return
+  }
+  router.push({ name: 'Search', query: { q } })
+}
+
+watch(
+  () => route.query.q,
+  (q) => {
+    searchKeyword.value = routeQueryValue(q)
+  },
+  { immediate: true },
+)
 </script>
 
 <style scoped>
@@ -79,6 +125,7 @@ async function handleLogout() {
 .header-left {
   display: flex;
   align-items: center;
+  flex: 0 0 auto;
 }
 
 .logo {
@@ -99,6 +146,20 @@ async function handleLogout() {
   display: flex;
   align-items: center;
   gap: var(--spacing-md);
+  flex: 0 0 auto;
+}
+
+.header-center {
+  flex: 1;
+  min-width: 120px;
+  display: flex;
+  justify-content: center;
+  padding: 0 var(--spacing-lg);
+}
+
+.header-search {
+  width: 100%;
+  max-width: 360px;
 }
 
 .user-dropdown {
@@ -120,6 +181,12 @@ async function handleLogout() {
 @media (max-width: 767px) {
   .app-header {
     padding: 0 var(--spacing-md);
+  }
+  .header-center {
+    padding: 0 var(--spacing-sm);
+  }
+  .header-search {
+    max-width: 220px;
   }
   .logo-text {
     display: none;

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -22,6 +22,12 @@ const routes: RouteRecordRaw[] = [
     meta: { title: '板块帖子' },
   },
   {
+    path: '/search',
+    name: 'Search',
+    component: () => import('@/views/search/SearchView.vue'),
+    meta: { title: '搜索帖子' },
+  },
+  {
     path: '/posts/:id',
     name: 'PostDetail',
     component: () => import('@/views/post/PostDetailView.vue'),

--- a/frontend/src/views/search/SearchView.vue
+++ b/frontend/src/views/search/SearchView.vue
@@ -1,0 +1,304 @@
+<template>
+  <div class="search-page">
+    <div class="content-container">
+      <el-breadcrumb separator=">">
+        <el-breadcrumb-item :to="{ name: 'Home' }">首页</el-breadcrumb-item>
+        <el-breadcrumb-item>搜索</el-breadcrumb-item>
+      </el-breadcrumb>
+
+      <div class="search-header">
+        <h1>搜索帖子</h1>
+        <div class="keyword-row">
+          <el-input
+            v-model="keyword"
+            clearable
+            placeholder="搜索标题或正文"
+            @keyup.enter="submitSearch()"
+          >
+            <template #prefix>
+              <el-icon><Search /></el-icon>
+            </template>
+          </el-input>
+          <el-button type="primary" @click="submitSearch()">搜索</el-button>
+        </div>
+      </div>
+
+      <div class="filters">
+        <el-select
+          v-model="selectedBoardId"
+          clearable
+          placeholder="全部板块"
+          @change="handleFilterChange"
+        >
+          <el-option
+            v-for="board in boardStore.boards"
+            :key="board.id"
+            :label="board.name"
+            :value="board.id"
+          />
+        </el-select>
+
+        <el-date-picker
+          v-model="dateRange"
+          type="daterange"
+          value-format="YYYY-MM-DD"
+          start-placeholder="开始日期"
+          end-placeholder="结束日期"
+          @change="handleFilterChange"
+        />
+
+        <el-radio-group v-model="sortBy" size="small" @change="handleFilterChange">
+          <el-radio-button value="relevance">相关度</el-radio-button>
+          <el-radio-button value="hot">热度</el-radio-button>
+          <el-radio-button value="time">时间</el-radio-button>
+        </el-radio-group>
+      </div>
+
+      <div v-if="searched && !loading" class="result-summary">
+        找到 {{ pagination.total }} 条与“{{ routeKeyword }}”相关的帖子
+      </div>
+
+      <LoadingSkeleton v-if="loading" type="list-item" :count="5" />
+      <ErrorState v-else-if="error" :message="error" @retry="fetchSearch" />
+      <EmptyState
+        v-else-if="!searched"
+        title="输入关键词开始搜索"
+        description="可以按板块、日期范围和排序方式缩小结果"
+      />
+      <EmptyState
+        v-else-if="!results.length"
+        title="没有找到相关帖子"
+        description="换一个关键词或放宽筛选条件试试"
+      />
+
+      <div v-else>
+        <PostListItem v-for="post in results" :key="post.id" :post="post" @click="goToPost" />
+        <PaginationBar
+          :current-page="pagination.page"
+          :page-size="pagination.pageSize"
+          :total="pagination.total"
+          @page-change="handlePageChange"
+          @size-change="handleSizeChange"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, reactive, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { Search } from '@element-plus/icons-vue'
+import { searchAPI, type SearchSort } from '@/api/search'
+import { useBoardStore } from '@/stores/boards'
+import { DEFAULT_PAGE_SIZE } from '@/utils/constants'
+import type { PostRead } from '@/types/post'
+import PostListItem from '@/components/post/PostListItem.vue'
+import PaginationBar from '@/components/common/PaginationBar.vue'
+import LoadingSkeleton from '@/components/common/LoadingSkeleton.vue'
+import ErrorState from '@/components/common/ErrorState.vue'
+import EmptyState from '@/components/common/EmptyState.vue'
+
+const route = useRoute()
+const router = useRouter()
+const boardStore = useBoardStore()
+
+const keyword = ref('')
+const selectedBoardId = ref<string | undefined>()
+const dateRange = ref<string[] | null>(null)
+const sortBy = ref<SearchSort>('relevance')
+const results = ref<PostRead[]>([])
+const loading = ref(false)
+const error = ref<string | null>(null)
+const searched = ref(false)
+
+const pagination = reactive({
+  page: 1,
+  pageSize: DEFAULT_PAGE_SIZE,
+  total: 0,
+  totalPages: 0,
+})
+
+const routeKeyword = computed(() => queryValue(route.query.q))
+
+function queryValue(value: unknown): string {
+  if (Array.isArray(value)) return String(value[0] || '')
+  return value ? String(value) : ''
+}
+
+function syncFromRoute() {
+  keyword.value = queryValue(route.query.q)
+  selectedBoardId.value = queryValue(route.query.board_id) || undefined
+
+  const startDate = queryValue(route.query.start_date)
+  const endDate = queryValue(route.query.end_date)
+  dateRange.value = startDate || endDate ? [startDate, endDate] : null
+
+  const nextSort = queryValue(route.query.sort_by)
+  sortBy.value = ['relevance', 'hot', 'time'].includes(nextSort)
+    ? (nextSort as SearchSort)
+    : 'relevance'
+
+  pagination.page = Number(queryValue(route.query.page)) || 1
+  pagination.pageSize = Number(queryValue(route.query.page_size)) || DEFAULT_PAGE_SIZE
+}
+
+function buildQuery(page = 1, pageSize = pagination.pageSize) {
+  const q = keyword.value.trim()
+  const [startDate, endDate] = dateRange.value || []
+  return {
+    q,
+    ...(selectedBoardId.value ? { board_id: selectedBoardId.value } : {}),
+    ...(startDate ? { start_date: startDate } : {}),
+    ...(endDate ? { end_date: endDate } : {}),
+    ...(sortBy.value !== 'relevance' ? { sort_by: sortBy.value } : {}),
+    ...(page > 1 ? { page: String(page) } : {}),
+    ...(pageSize !== DEFAULT_PAGE_SIZE ? { page_size: String(pageSize) } : {}),
+  }
+}
+
+function submitSearch(page = 1, pageSize = pagination.pageSize) {
+  if (!keyword.value.trim()) {
+    router.push({ name: 'Search' })
+    return
+  }
+  router.push({ name: 'Search', query: buildQuery(page, pageSize) })
+}
+
+function handleFilterChange() {
+  submitSearch(1, pagination.pageSize)
+}
+
+function handlePageChange(page: number) {
+  submitSearch(page, pagination.pageSize)
+}
+
+function handleSizeChange(size: number) {
+  submitSearch(1, size)
+}
+
+async function fetchSearch() {
+  error.value = null
+  if (!keyword.value.trim()) {
+    searched.value = false
+    results.value = []
+    Object.assign(pagination, { page: 1, total: 0, totalPages: 0 })
+    return
+  }
+
+  searched.value = true
+  loading.value = true
+  try {
+    const [startDate, endDate] = dateRange.value || []
+    const data = await searchAPI.searchPosts({
+      q: keyword.value.trim(),
+      board_id: selectedBoardId.value,
+      start_date: startDate || undefined,
+      end_date: endDate || undefined,
+      sort_by: sortBy.value,
+      page: pagination.page,
+      page_size: pagination.pageSize,
+    })
+    results.value = data.items
+    Object.assign(pagination, {
+      page: data.pagination.page,
+      pageSize: data.pagination.page_size,
+      total: data.pagination.total,
+      totalPages: data.pagination.total_pages,
+    })
+  } catch {
+    error.value = '搜索失败'
+  } finally {
+    loading.value = false
+  }
+}
+
+function goToPost(postId: string) {
+  router.push(`/posts/${postId}`)
+}
+
+onMounted(async () => {
+  await boardStore.fetchBoards()
+  syncFromRoute()
+  await fetchSearch()
+})
+
+watch(
+  () => route.fullPath,
+  async () => {
+    syncFromRoute()
+    await fetchSearch()
+  },
+)
+</script>
+
+<style scoped>
+.search-page {
+  min-height: calc(100vh - var(--header-height) - var(--footer-height));
+}
+
+.content-container {
+  max-width: var(--content-max-width);
+  margin: 0 auto;
+  padding: var(--spacing-lg) var(--spacing-md);
+}
+
+.search-header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: var(--spacing-lg);
+  margin: var(--spacing-lg) 0;
+}
+
+.search-header h1 {
+  font-size: var(--font-size-xxl);
+  font-weight: 700;
+  color: var(--color-text-primary);
+}
+
+.keyword-row {
+  display: flex;
+  width: min(560px, 100%);
+  gap: var(--spacing-sm);
+}
+
+.filters {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--spacing-md);
+  margin-bottom: var(--spacing-md);
+}
+
+.filters :deep(.el-select) {
+  width: 180px;
+}
+
+.filters :deep(.el-date-editor) {
+  width: 280px;
+}
+
+.result-summary {
+  margin-bottom: var(--spacing-sm);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+}
+
+@media (max-width: 767px) {
+  .search-header {
+    display: block;
+  }
+
+  .search-header h1 {
+    margin-bottom: var(--spacing-md);
+  }
+
+  .keyword-row,
+  .filters :deep(.el-select),
+  .filters :deep(.el-date-editor) {
+    width: 100%;
+  }
+}
+</style>
+


### PR DESCRIPTION
Closes #42

## Summary
- Add post search API with keyword, board/date filters, and relevance/hot/time sorting
- Add PostgreSQL search_document/search_vector migration, trigger, and GIN index
- Add frontend search box and search results page

## Tests
- python -m pytest tests/test_search.py
- pnpm run lint
- pnpm run type-check
- pnpm run build