### PR TITLE
feat(auth,board): board_master role, mute, and related bug fixes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+# Force LF line endings for all text files (avoids CRLF warnings on Windows)
+* text=auto eol=lf
+
+# Binary files
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.svg binary
+*.woff binary
+*.woff2 binary
+*.ttf binary
+*.eot binary

--- a/backend/app/deps/auth.py
+++ b/backend/app/deps/auth.py
@@ -64,3 +64,45 @@ def require_admin(current_user: User = Depends(get_current_user)) -> User:
     if current_user.role != "admin":
         raise HTTPException(status_code=403, detail="Admin required")
     return current_user
+
+
+def check_not_muted(current_user: User) -> None:
+    """Raise 403 if user is currently muted."""
+    if current_user.muted_until is None:
+        return
+    expired = current_user.muted_until
+    if expired.tzinfo is None:
+        expired = expired.replace(tzinfo=timezone.utc)
+    if expired > datetime.now(timezone.utc):
+        raise HTTPException(
+            status_code=403,
+            detail=f"You are muted until {expired.isoformat()}",
+        )
+
+
+def check_can_moderate_post(db: Session, current_user: User, post: object) -> None:
+    """Raise 403 if user cannot moderate this post.
+    Admins can always moderate. Board masters can moderate posts in their boards."""
+    if current_user.role == "admin":
+        return
+    # Lazy import to avoid circular dependency
+    from app.services.board_master_service import BoardMasterService
+
+    bm_service = BoardMasterService()
+    if bm_service.is_board_master(db, board_id=post.board_id, user_id=current_user.id):
+        return
+    raise HTTPException(status_code=403, detail="Admin or board master required")
+
+
+def check_can_moderate_board(db: Session, current_user: User, board_id: UUID) -> None:
+    """Raise 403 if user cannot moderate this board.
+    Admins can always moderate. Board masters of this specific board can moderate."""
+    if current_user.role == "admin":
+        return
+    # Lazy import to avoid circular dependency
+    from app.services.board_master_service import BoardMasterService
+
+    bm_service = BoardMasterService()
+    if bm_service.is_board_master(db, board_id=board_id, user_id=current_user.id):
+        return
+    raise HTTPException(status_code=403, detail="Admin or board master required")

--- a/backend/app/deps/services.py
+++ b/backend/app/deps/services.py
@@ -9,6 +9,7 @@ from app.services.notification_service import NotificationService
 from app.services.like_service import LikeService
 from app.services.comment_service import CommentService
 from app.services.media_service import MediaService
+from app.services.board_master_service import BoardMasterService
 from app.services.search_service import SearchService
 from app.storage.factory import get_storage_backend
 from app.services.announcement_service import AnnouncementService
@@ -56,6 +57,10 @@ def get_media_service() -> MediaService:
     return MediaService(storage=storage)
 
 
+def get_board_master_service() -> BoardMasterService:
+    return BoardMasterService()
+
+
 def get_announcement_service() -> AnnouncementService:
     return AnnouncementService()
 
@@ -71,5 +76,6 @@ __all__ = [
     "get_like_service",
     "get_comment_service",
     "get_media_service",
+    "get_board_master_service",
     "get_announcement_service",
 ]

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -16,6 +16,7 @@ from app.models.comment import Comment
 from app.models.notification import Notification
 from app.models.like import PostLike, CommentLike
 from app.models.media import MediaAsset, PostAttachment
+from app.models.board_master import BoardMaster
 from app.models.announcement import Announcement
 
 __all__ = [
@@ -31,5 +32,6 @@ __all__ = [
     "CommentLike",
     "MediaAsset",
     "PostAttachment",
+    "BoardMaster",
     "Announcement",
 ]

--- a/backend/app/models/board.py
+++ b/backend/app/models/board.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
     from app.models.post import Post
+    from app.models.board_master import BoardMaster
 
 from sqlalchemy import Index, String, Integer, text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -36,3 +37,6 @@ class Board(Base, IDMixin, TimestampMixin):
     sort_order: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
 
     posts: Mapped[list["Post"]] = relationship("Post", back_populates="board")
+    board_masters: Mapped[list["BoardMaster"]] = relationship(
+        "BoardMaster", back_populates="board"
+    )

--- a/backend/app/models/board_master.py
+++ b/backend/app/models/board_master.py
@@ -1,0 +1,30 @@
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from sqlalchemy import ForeignKey, Index, text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.base import Base, IDMixin, TimestampMixin
+
+if TYPE_CHECKING:
+    from app.models.board import Board
+    from app.models.user import User
+
+
+class BoardMaster(Base, IDMixin, TimestampMixin):
+    __tablename__ = "board_masters"
+    __table_args__ = (
+        Index(
+            "uq_board_masters_board_user",
+            "board_id",
+            "user_id",
+            unique=True,
+            postgresql_where=text("deleted_at IS NULL"),
+        ),
+    )
+
+    board_id: Mapped[UUID] = mapped_column(ForeignKey("boards.id"), nullable=False)
+    user_id: Mapped[UUID] = mapped_column(ForeignKey("users.id"), nullable=False)
+
+    board: Mapped["Board"] = relationship("Board", back_populates="board_masters")
+    user: Mapped["User"] = relationship("User", back_populates="board_masters")

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
     from app.models.post import Post
+    from app.models.board_master import BoardMaster
 
 from sqlalchemy import Boolean
 from sqlalchemy import CheckConstraint
@@ -50,4 +51,8 @@ class User(Base, IDMixin, TimestampMixin):
     status: Mapped[str] = mapped_column(String(20), nullable=False, default="active")
     email_verified: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     last_login_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True))
+    muted_until: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True))
     posts: Mapped[list["Post"]] = relationship("Post", back_populates="author")
+    board_masters: Mapped[list["BoardMaster"]] = relationship(
+        "BoardMaster", back_populates="user"
+    )

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -1,6 +1,6 @@
 from typing import List
 from uuid import UUID
-from datetime import datetime, date
+from datetime import datetime, date, timedelta, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.orm import Session
@@ -10,12 +10,14 @@ from app.deps.db import get_db
 from app.deps.services import (
     get_user_service,
     get_board_service,
+    get_board_master_service,
     get_announcement_service,
 )
 from app.deps.auth import require_admin
 from app.models.user import User
 from app.models.post import Post
 from app.models.comment import Comment
+from app.models.board import Board
 
 from app.schemas.response import (
     ApiResponse,
@@ -23,9 +25,10 @@ from app.schemas.response import (
     PaginatedData,
     PaginationInfo,
 )
-from app.schemas.user import AdminUserData, UpdateUserStatusRequest
+from app.schemas.user import AdminUserData, UpdateUserStatusRequest, MuteUserRequest
 from app.schemas.admin import AdminStatsResponse
 from app.schemas.board import BoardCreate, BoardUpdate, BoardRead
+from app.schemas.board_master import BoardMasterRead, AddBoardMasterRequest
 from app.schemas.announcement import (
     AnnouncementCreate,
     AnnouncementUpdate,
@@ -33,6 +36,7 @@ from app.schemas.announcement import (
 )
 from app.services.user_service import UserService
 from app.services.board_service import BoardService
+from app.services.board_master_service import BoardMasterService
 from app.services.announcement_service import AnnouncementService
 
 router = APIRouter(
@@ -136,6 +140,115 @@ def admin_delete_board(
     if not board:
         raise HTTPException(status_code=404, detail="Board not found")
     service.remove(db, db_obj=board)
+
+
+# ── Board Master Management ──
+
+
+@router.get(
+    "/boards/{board_id}/masters",
+    response_model=ApiResponse[List[BoardMasterRead]],
+)
+def admin_list_board_masters(
+    board_id: UUID,
+    db: Session = Depends(get_db),
+    service: BoardMasterService = Depends(get_board_master_service),
+):
+    """列出板块的版主（仅管理员）"""
+    board = (
+        db.query(Board).filter(Board.id == board_id, Board.deleted_at.is_(None)).first()
+    )
+    if not board:
+        raise HTTPException(status_code=404, detail="Board not found")
+    return ApiResponse(data=service.list_for_board(db, board_id))
+
+
+@router.post(
+    "/boards/{board_id}/masters",
+    response_model=ApiResponse[BoardMasterRead],
+    status_code=status.HTTP_201_CREATED,
+)
+def admin_add_board_master(
+    board_id: UUID,
+    payload: AddBoardMasterRequest,
+    db: Session = Depends(get_db),
+    service: BoardMasterService = Depends(get_board_master_service),
+):
+    """添加版主（仅管理员）"""
+    board = (
+        db.query(Board).filter(Board.id == board_id, Board.deleted_at.is_(None)).first()
+    )
+    if not board:
+        raise HTTPException(status_code=404, detail="Board not found")
+    user = (
+        db.query(User)
+        .filter(User.id == payload.user_id, User.deleted_at.is_(None))
+        .first()
+    )
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    result = service.add(db, board_id=board_id, user_id=payload.user_id)
+    db.refresh(result, attribute_names=["user"])
+    return ApiResponse(data=result)
+
+
+@router.delete(
+    "/boards/{board_id}/masters/{user_id}",
+    response_model=ApiResponse,
+)
+def admin_remove_board_master(
+    board_id: UUID,
+    user_id: UUID,
+    db: Session = Depends(get_db),
+    service: BoardMasterService = Depends(get_board_master_service),
+):
+    """移除版主（仅管理员）"""
+    service.remove(db, board_id=board_id, user_id=user_id)
+    return ApiResponse(message="Board master removed")
+
+
+# ── Mute / Unmute ──
+
+
+@router.post("/users/{id}/mute", response_model=ApiResponse[AdminUserData])
+def admin_mute_user(
+    id: str,
+    payload: MuteUserRequest,
+    db: Session = Depends(get_db),
+    service: UserService = Depends(get_user_service),
+):
+    """禁言用户（仅管理员）"""
+    try:
+        uid = UUID(id)
+    except ValueError:
+        raise HTTPException(status_code=404, detail="User not found")
+    user = db.query(User).filter(User.id == uid, User.deleted_at.is_(None)).first()
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    user.muted_until = datetime.now(timezone.utc) + timedelta(
+        minutes=payload.duration_minutes
+    )
+    db.commit()
+    db.refresh(user)
+    return ApiResponse(data=service.get_admin_user_data(user))
+
+
+@router.delete("/users/{id}/mute", response_model=ApiResponse)
+def admin_unmute_user(
+    id: str,
+    db: Session = Depends(get_db),
+):
+    """解除禁言（仅管理员）"""
+    try:
+        uid = UUID(id)
+    except ValueError:
+        raise HTTPException(status_code=404, detail="User not found")
+    user = db.query(User).filter(User.id == uid, User.deleted_at.is_(None)).first()
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    user.muted_until = None
+    db.commit()
+    return ApiResponse(message="User unmuted")
 
 
 # ---------- announcements ----------

--- a/backend/app/routers/boards.py
+++ b/backend/app/routers/boards.py
@@ -1,4 +1,6 @@
+from typing import List
 from uuid import UUID
+from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter
 from fastapi import Depends
@@ -6,15 +8,18 @@ from fastapi import HTTPException
 from fastapi import status
 from sqlalchemy.orm import Session
 
-from app.deps.auth import require_admin
+from app.deps.auth import require_admin, get_current_user, check_can_moderate_board
 from app.deps.db import get_db
-from app.deps.services import get_board_service
+from app.deps.services import get_board_service, get_board_master_service
 from app.models.user import User
 from app.schemas.board import BoardCreate
 from app.schemas.board import BoardRead
 from app.schemas.board import BoardUpdate
+from app.schemas.board_master import BoardMasterRead
 from app.schemas.response import ApiResponse
+from app.schemas.user import MuteUserRequest
 from app.services.board_service import BoardService
+from app.services.board_master_service import BoardMasterService
 
 router = APIRouter(prefix="/boards", tags=["boards"])
 
@@ -87,3 +92,43 @@ def delete_board(
         raise HTTPException(status_code=404, detail="Board not found")
     service.remove(db, db_obj=board)
     return ApiResponse(message="Board deleted")
+
+
+# ── Board Masters (public) ──
+
+
+@router.get("/{id}/masters", response_model=ApiResponse[List[BoardMasterRead]])
+def list_board_masters(
+    id: UUID,
+    db: Session = Depends(get_db),
+    service: BoardMasterService = Depends(get_board_master_service),
+):
+    """列出板块的版主（公开）"""
+    return ApiResponse(data=service.list_for_board(db, id))
+
+
+# ── Board Master Moderation ──
+
+
+@router.post("/{board_id}/users/{user_id}/mute", response_model=ApiResponse)
+def board_master_mute_user(
+    board_id: UUID,
+    user_id: UUID,
+    payload: MuteUserRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """版主禁言用户（管理员或该板块版主）"""
+    check_can_moderate_board(db, current_user, board_id)
+    target = (
+        db.query(User).filter(User.id == user_id, User.deleted_at.is_(None)).first()
+    )
+    if not target:
+        raise HTTPException(status_code=404, detail="User not found")
+    if target.role == "admin" and current_user.role != "admin":
+        raise HTTPException(status_code=403, detail="Cannot mute an admin")
+    target.muted_until = datetime.now(timezone.utc) + timedelta(
+        minutes=payload.duration_minutes
+    )
+    db.commit()
+    return ApiResponse(message=f"User muted for {payload.duration_minutes} minutes")

--- a/backend/app/routers/comments.py
+++ b/backend/app/routers/comments.py
@@ -4,10 +4,11 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.orm import Session
 
-from app.deps.auth import get_current_user
+from app.deps.auth import get_current_user, check_not_muted, check_can_moderate_post
 from app.deps.db import get_db
 from app.deps.services import get_comment_service
 from app.models.user import User
+from app.models.post import Post
 from app.schemas.comment import (
     CommentCreate,
     CommentRead,
@@ -34,6 +35,7 @@ def create_comment(
     current_user: User = Depends(get_current_user),
     service: CommentService = Depends(get_comment_service),
 ):
+    check_not_muted(current_user)
     comment = service.create(db, obj_in=payload, author_id=current_user.id)
     return ApiResponse(data=comment)
 
@@ -95,6 +97,10 @@ def delete_comment(
     if not comment:
         raise HTTPException(status_code=404, detail="Comment not found")
     if comment.author_id != current_user.id and current_user.role != "admin":
-        raise HTTPException(status_code=403, detail="Permission denied")
+        post = db.query(Post).filter(Post.id == comment.post_id).first()
+        if post:
+            check_can_moderate_post(db, current_user, post)
+        else:
+            raise HTTPException(status_code=403, detail="Permission denied")
     service.remove(db, db_obj=comment)
     return ApiResponse(message="Comment deleted")

--- a/backend/app/routers/likes.py
+++ b/backend/app/routers/likes.py
@@ -1,16 +1,36 @@
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, Query, status
 from sqlalchemy.orm import Session
 
 from app.deps.auth import get_current_user
 from app.deps.db import get_db
 from app.deps.services import get_like_service
 from app.models.user import User
+from app.schemas.like import PostLikeStatus
 from app.schemas.response import ApiResponse
 from app.services.like_service import LikeService
 
 router = APIRouter(prefix="/likes", tags=["likes"])
+
+
+@router.get("/my-status", response_model=ApiResponse[PostLikeStatus])
+def get_my_like_status(
+    post_id: UUID = Query(...),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+    service: LikeService = Depends(get_like_service),
+):
+    is_liked = service.is_post_liked(db, post_id=post_id, user_id=current_user.id)
+    comment_ids = service.get_liked_comment_ids_for_post(
+        db, post_id=post_id, user_id=current_user.id
+    )
+    return ApiResponse(
+        data=PostLikeStatus(
+            is_liked=is_liked,
+            liked_comment_ids=comment_ids,
+        )
+    )
 
 
 @router.post(

--- a/backend/app/routers/posts.py
+++ b/backend/app/routers/posts.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import Session
 
 from app.deps.db import get_db
 from app.deps.services import get_post_service
-from app.deps.auth import get_current_user
+from app.deps.auth import get_current_user, check_not_muted, check_can_moderate_post
 from app.models.user import User
 from app.schemas.response import (
     ApiResponse,
@@ -33,6 +33,7 @@ def create_post(
     service: PostService = Depends(get_post_service),
 ):
     """发帖：自动填充作者 ID"""
+    check_not_muted(current_user)
     post = service.create(db, obj_in=payload, author_id=current_user.id)
     return ApiResponse(data=post)
 
@@ -100,12 +101,12 @@ def delete_post(
     current_user: User = Depends(get_current_user),
     service: PostService = Depends(get_post_service),
 ):
-    """软删除帖子：仅限作者或管理员"""
+    """软删除帖子：仅限作者、管理员或版主"""
     post = service.get_by_id(db, id)
     if not post:
         raise HTTPException(status_code=404, detail="Post not found")
     if post.author_id != current_user.id and current_user.role != "admin":
-        raise HTTPException(status_code=403, detail="Permission denied")
+        check_can_moderate_post(db, current_user, post)
 
     service.remove(db, db_obj=post)
     return ApiResponse(message="Post deleted")
@@ -119,12 +120,11 @@ def pin_post(
     db: Session = Depends(get_db),
     service: PostService = Depends(get_post_service),
 ):
-    """置顶/取消置顶：仅管理员"""
-    if current_user.role != "admin":
-        raise HTTPException(status_code=403, detail="Admin only")
+    """置顶/取消置顶：管理员或版主"""
     post = service.get_by_id(db, id)
     if not post:
         raise HTTPException(status_code=404, detail="Post not found")
+    check_can_moderate_post(db, current_user, post)
     return ApiResponse(
         data=service.update_special_status(
             db, db_obj=post, field="is_pinned", val=is_pinned
@@ -140,12 +140,11 @@ def feature_post(
     db: Session = Depends(get_db),
     service: PostService = Depends(get_post_service),
 ):
-    """加精/取消加精：仅管理员"""
-    if current_user.role != "admin":
-        raise HTTPException(status_code=403, detail="Admin only")
+    """加精/取消加精：管理员或版主"""
     post = service.get_by_id(db, id)
     if not post:
         raise HTTPException(status_code=404, detail="Post not found")
+    check_can_moderate_post(db, current_user, post)
     return ApiResponse(
         data=service.update_special_status(
             db, db_obj=post, field="is_featured", val=is_featured

--- a/backend/app/schemas/board.py
+++ b/backend/app/schemas/board.py
@@ -17,6 +17,7 @@ class BoardRead(BaseModel):
     slug: str
     description: str | None = None
     sort_order: int
+    post_count: int = 0
     created_at: datetime
     updated_at: datetime
 

--- a/backend/app/schemas/board_master.py
+++ b/backend/app/schemas/board_master.py
@@ -1,0 +1,25 @@
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
+
+
+class BoardMasterUserInfo(BaseModel):
+    id: UUID
+    username: str
+    nickname: str | None = None
+    avatar_url: str | None = None
+    model_config = ConfigDict(from_attributes=True)
+
+
+class BoardMasterRead(BaseModel):
+    id: UUID
+    board_id: UUID
+    user_id: UUID
+    user: BoardMasterUserInfo
+    created_at: datetime
+    model_config = ConfigDict(from_attributes=True)
+
+
+class AddBoardMasterRequest(BaseModel):
+    user_id: UUID

--- a/backend/app/schemas/like.py
+++ b/backend/app/schemas/like.py
@@ -1,0 +1,8 @@
+from uuid import UUID
+
+from pydantic import BaseModel
+
+
+class PostLikeStatus(BaseModel):
+    is_liked: bool
+    liked_comment_ids: list[UUID]

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -2,6 +2,10 @@ from pydantic import BaseModel
 from pydantic import Field
 
 
+class MuteUserRequest(BaseModel):
+    duration_minutes: int = Field(gt=0, le=43200)  # max 30 days
+
+
 class UpdateProfileRequest(BaseModel):
     nickname: str | None = Field(default=None, min_length=1, max_length=64)
     avatar_url: str | None = Field(default=None, max_length=1024)
@@ -15,6 +19,7 @@ class UserProfileData(BaseModel):
     avatar_url: str | None = None
     role: str
     status: str
+    muted_until: str | None = None
     created_at: str
     updated_at: str
 

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -135,6 +135,10 @@ class AuthService:
     ) -> ResetPasswordData:
         if not verify_password(payload.old_password, user.password_hash):
             raise HTTPException(status_code=401, detail="Old password is incorrect")
+        if verify_password(payload.new_password, user.password_hash):
+            raise HTTPException(
+                status_code=422, detail="New password must differ from old password"
+            )
         user.password_hash = hash_password(payload.new_password)
         db.add(user)
         try:

--- a/backend/app/services/board_master_service.py
+++ b/backend/app/services/board_master_service.py
@@ -1,0 +1,80 @@
+from datetime import datetime, timezone
+from typing import List
+from uuid import UUID
+
+from sqlalchemy.orm import Session, joinedload
+
+from app.models.board_master import BoardMaster
+
+
+class BoardMasterService:
+    def list_for_board(self, db: Session, board_id: UUID) -> List[BoardMaster]:
+        return (
+            db.query(BoardMaster)
+            .options(joinedload(BoardMaster.user))
+            .filter(
+                BoardMaster.board_id == board_id,
+                BoardMaster.deleted_at.is_(None),
+            )
+            .all()
+        )
+
+    def add(self, db: Session, *, board_id: UUID, user_id: UUID) -> BoardMaster:
+        existing = (
+            db.query(BoardMaster)
+            .filter(
+                BoardMaster.board_id == board_id,
+                BoardMaster.user_id == user_id,
+            )
+            .first()
+        )
+        if existing:
+            if existing.deleted_at is not None:
+                existing.deleted_at = None
+                existing.updated_at = datetime.now(timezone.utc)
+                db.commit()
+                db.refresh(existing)
+            return existing
+
+        db_obj = BoardMaster(board_id=board_id, user_id=user_id)
+        db.add(db_obj)
+        db.commit()
+        db.refresh(db_obj)
+        return db_obj
+
+    def remove(self, db: Session, *, board_id: UUID, user_id: UUID) -> None:
+        record = (
+            db.query(BoardMaster)
+            .filter(
+                BoardMaster.board_id == board_id,
+                BoardMaster.user_id == user_id,
+                BoardMaster.deleted_at.is_(None),
+            )
+            .first()
+        )
+        if record:
+            record.deleted_at = datetime.now(timezone.utc)
+            db.commit()
+
+    def is_board_master(self, db: Session, *, board_id: UUID, user_id: UUID) -> bool:
+        return (
+            db.query(BoardMaster)
+            .filter(
+                BoardMaster.board_id == board_id,
+                BoardMaster.user_id == user_id,
+                BoardMaster.deleted_at.is_(None),
+            )
+            .first()
+            is not None
+        )
+
+    def get_board_ids_for_user(self, db: Session, user_id: UUID) -> List[UUID]:
+        records = (
+            db.query(BoardMaster)
+            .filter(
+                BoardMaster.user_id == user_id,
+                BoardMaster.deleted_at.is_(None),
+            )
+            .all()
+        )
+        return [r.board_id for r in records]

--- a/backend/app/services/board_service.py
+++ b/backend/app/services/board_service.py
@@ -2,32 +2,62 @@ from datetime import datetime, timezone
 from typing import Optional, List
 from uuid import UUID
 
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from app.models.board import Board
+from app.models.post import Post
 from app.schemas.board import BoardCreate, BoardUpdate
+
+
+def _attach_post_counts(db: Session, boards: list[Board]) -> None:
+    """Attach post_count to each board via a single batch query."""
+    if not boards:
+        return
+    board_ids = [b.id for b in boards]
+    rows = (
+        db.query(Post.board_id, func.count(Post.id))
+        .filter(
+            Post.board_id.in_(board_ids),
+            Post.deleted_at.is_(None),
+            Post.status == "normal",
+        )
+        .group_by(Post.board_id)
+        .all()
+    )
+    counts = {row[0]: row[1] for row in rows}
+    for b in boards:
+        setattr(b, "post_count", counts.get(b.id, 0))
 
 
 class BoardService:
     def get_all(self, db: Session) -> List[Board]:
-        return (
+        boards = (
             db.query(Board)
             .filter(Board.deleted_at.is_(None))
             .order_by(Board.sort_order, Board.created_at)
             .all()
         )
+        _attach_post_counts(db, boards)
+        return boards
 
     def get_by_id(self, db: Session, id: UUID) -> Optional[Board]:
-        return (
+        board = (
             db.query(Board).filter(Board.id == id, Board.deleted_at.is_(None)).first()
         )
+        if board:
+            _attach_post_counts(db, [board])
+        return board
 
     def get_by_slug(self, db: Session, slug: str) -> Optional[Board]:
-        return (
+        board = (
             db.query(Board)
             .filter(Board.slug == slug, Board.deleted_at.is_(None))
             .first()
         )
+        if board:
+            _attach_post_counts(db, [board])
+        return board
 
     def slug_exists(
         self, db: Session, slug: str, *, exclude_id: UUID | None = None

--- a/backend/app/services/like_service.py
+++ b/backend/app/services/like_service.py
@@ -142,6 +142,31 @@ class LikeService:
         db.refresh(comment)
         return comment
 
+    def get_liked_comment_ids_for_post(
+        self, db: Session, *, post_id: UUID, user_id: UUID
+    ) -> list[UUID]:
+        """Return comment IDs the user has liked within a given post."""
+        rows = (
+            db.query(CommentLike.comment_id)
+            .join(Comment, Comment.id == CommentLike.comment_id)
+            .filter(
+                Comment.post_id == post_id,
+                CommentLike.user_id == user_id,
+                Comment.deleted_at.is_(None),
+            )
+            .all()
+        )
+        return [row[0] for row in rows]
+
+    def is_post_liked(self, db: Session, *, post_id: UUID, user_id: UUID) -> bool:
+        """Check if a user has liked a post."""
+        return (
+            db.query(PostLike)
+            .filter(PostLike.post_id == post_id, PostLike.user_id == user_id)
+            .first()
+            is not None
+        )
+
     # ------------------------------------------------------------------
     # private helpers
     # ------------------------------------------------------------------

--- a/backend/app/services/user_service.py
+++ b/backend/app/services/user_service.py
@@ -21,6 +21,7 @@ class UserService:
             avatar_url=user.avatar_url,
             role=user.role,
             status=user.status,
+            muted_until=user.muted_until.isoformat() if user.muted_until else None,
             created_at=user.created_at.isoformat(),
             updated_at=user.updated_at.isoformat(),
         )
@@ -83,6 +84,21 @@ class UserService:
             for u in users
         ]
         return items, total
+
+    def get_admin_user_data(self, user: User) -> AdminUserData:
+        return AdminUserData(
+            id=str(user.id),
+            username=user.username,
+            email=user.email,
+            nickname=user.nickname,
+            avatar_url=user.avatar_url,
+            role=user.role,
+            status=user.status,
+            last_login_at=(
+                user.last_login_at.isoformat() if user.last_login_at else None
+            ),
+            created_at=user.created_at.isoformat(),
+        )
 
     def update_status(
         self, db: Session, user_id: str, payload: UpdateUserStatusRequest

--- a/backend/migrations/versions/5b0af807c62a_merge_heads.py
+++ b/backend/migrations/versions/5b0af807c62a_merge_heads.py
@@ -8,7 +8,6 @@ Create Date: 2026-06-08 15:48:25.808814
 
 from typing import Sequence, Union
 
-
 # revision identifiers, used by Alembic.
 revision: str = "5b0af807c62a"
 down_revision: Union[str, Sequence[str], None] = ("4a2e8f1b3c6d", "5f6a7b8c9d10")

--- a/backend/migrations/versions/d1f8a3b6e2c9_add_board_masters_and_muted_until.py
+++ b/backend/migrations/versions/d1f8a3b6e2c9_add_board_masters_and_muted_until.py
@@ -1,0 +1,68 @@
+"""add_board_masters_and_muted_until
+
+Revision ID: d1f8a3b6e2c9
+Revises: 5b0af807c62a
+Create Date: 2026-06-08 13:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "d1f8a3b6e2c9"
+down_revision: Union[str, Sequence[str], None] = "5b0af807c62a"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        "users",
+        sa.Column("muted_until", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_table(
+        "board_masters",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("board_id", sa.UUID(), nullable=False),
+        sa.Column("user_id", sa.UUID(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["board_id"],
+            ["boards.id"],
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["users.id"],
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "uq_board_masters_board_user",
+        "board_masters",
+        ["board_id", "user_id"],
+        unique=True,
+        postgresql_where=sa.text("deleted_at IS NULL"),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index("uq_board_masters_board_user", table_name="board_masters")
+    op.drop_table("board_masters")
+    op.drop_column("users", "muted_until")

--- a/backend/migrations/versions/e1c912af7df6_add_likes_tables_and_post_like_count.py
+++ b/backend/migrations/versions/e1c912af7df6_add_likes_tables_and_post_like_count.py
@@ -65,7 +65,12 @@ def upgrade() -> None:
         sa.PrimaryKeyConstraint("id"),
         sa.UniqueConstraint("comment_id", "user_id", name="uq_comment_likes"),
     )
-    op.add_column("posts", sa.Column("like_count", sa.BigInteger(), nullable=False))
+    op.add_column(
+        "posts",
+        sa.Column(
+            "like_count", sa.BigInteger(), nullable=False, server_default=sa.text("0")
+        ),
+    )
     # ### end Alembic commands ###
 
 

--- a/backend/tests/test_board_master.py
+++ b/backend/tests/test_board_master.py
@@ -1,0 +1,656 @@
+"""
+BoardMaster + Mute 集成测试：版主权限、CRUD、禁言
+
+使用 AsyncClient + 内存 SQLite 替代真实 Postgres。
+"""
+
+import uuid
+
+import pytest
+import pytest_asyncio
+from fastapi import status
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.database import get_db
+from app.main import app
+from app.models.base import Base
+from app.models.board import Board
+from app.models.user import User
+from app.utils.security import hash_password
+
+SQLALCHEMY_DATABASE_URL = "sqlite:///test_board_master.db"
+
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
+)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+API_PREFIX = "/api/v1"
+POSTS_URL = f"{API_PREFIX}/posts"
+POSTS_LIST = f"{POSTS_URL}/"
+COMMENTS_URL = f"{API_PREFIX}/comments"
+COMMENTS_LIST = f"{COMMENTS_URL}/"
+AUTH_PREFIX = f"{API_PREFIX}/auth"
+BOARDS_URL = f"{API_PREFIX}/boards"
+ADMIN_URL = f"{API_PREFIX}/admin"
+
+POST_PAYLOAD = {"title": "Test Title", "content": "Hello world"}
+
+
+@pytest.fixture(autouse=True)
+def _setup_db():
+    Base.metadata.create_all(bind=engine)
+    yield
+    Base.metadata.drop_all(bind=engine)
+
+
+def _override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@pytest.fixture()
+def db_session():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@pytest_asyncio.fixture()
+async def client():
+    app.dependency_overrides[get_db] = _override_get_db
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+    app.dependency_overrides.clear()
+
+
+# ---------- helpers ----------
+
+
+def _create_user(
+    db, username: str, email: str, role: str = "user", email_verified: bool = True
+) -> User:
+    user = User(
+        username=username,
+        email=email,
+        password_hash=hash_password("securepass123"),
+        nickname=username,
+        role=role,
+        status="active",
+        email_verified=email_verified,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def _create_board(db, name: str = "Test Board", slug: str = "test-board") -> Board:
+    board = Board(name=name, slug=slug, description="test", sort_order=1)
+    db.add(board)
+    db.commit()
+    db.refresh(board)
+    return board
+
+
+async def _login(client: AsyncClient, account: str) -> str:
+    resp = await client.post(
+        f"{AUTH_PREFIX}/login",
+        json={"account": account, "password": "securepass123"},
+    )
+    return resp.json()["data"]["access_token"]
+
+
+async def _get_auth_client(client: AsyncClient, token: str) -> AsyncClient:
+    transport = ASGITransport(app=app)
+    return AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+
+async def _prepare_user_and_board(client, db_session, username="poster", role="user"):
+    user = _create_user(db_session, username, f"{username}@test.com", role=role)
+    token = await _login(client, username)
+    ac = await _get_auth_client(client, token)
+    board = _create_board(db_session, f"bd-{username}", f"slug-{username}")
+    return ac, user, board
+
+
+async def _make_board_master(
+    admin_client: AsyncClient, board_id: str, user_id: str
+) -> dict:
+    resp = await admin_client.post(
+        f"{ADMIN_URL}/boards/{board_id}/masters",
+        json={"user_id": user_id},
+    )
+    return resp.json()["data"]
+
+
+async def _create_post(
+    client: AsyncClient, board_id: str, title: str = "Test Post"
+) -> dict:
+    resp = await client.post(
+        POSTS_LIST, json={**POST_PAYLOAD, "title": title, "board_id": board_id}
+    )
+    return resp.json()["data"]
+
+
+# =============================== Board Master CRUD ===============================
+
+
+@pytest.mark.asyncio
+async def test_admin_can_add_board_master(client: AsyncClient, db_session):
+    admin_ac, _, board = await _prepare_user_and_board(
+        client, db_session, "bm_admin", "admin"
+    )
+    normal_ac, user, _ = await _prepare_user_and_board(
+        client, db_session, "bm_user", "user"
+    )
+
+    resp = await admin_ac.post(
+        f"{ADMIN_URL}/boards/{board.id}/masters",
+        json={"user_id": str(user.id)},
+    )
+    assert resp.status_code == status.HTTP_201_CREATED
+    data = resp.json()["data"]
+    assert data["board_id"] == str(board.id)
+    assert data["user_id"] == str(user.id)
+    assert data["user"]["username"] == "bm_user"
+
+
+@pytest.mark.asyncio
+async def test_admin_list_board_masters(client: AsyncClient, db_session):
+    admin_ac, _, board = await _prepare_user_and_board(
+        client, db_session, "bl_admin", "admin"
+    )
+    normal_ac, user, _ = await _prepare_user_and_board(
+        client, db_session, "bl_user", "user"
+    )
+    await _make_board_master(admin_ac, str(board.id), str(user.id))
+
+    resp = await admin_ac.get(f"{ADMIN_URL}/boards/{board.id}/masters")
+    assert resp.status_code == status.HTTP_200_OK
+    data = resp.json()["data"]
+    assert len(data) == 1
+    assert data[0]["user"]["username"] == "bl_user"
+
+
+@pytest.mark.asyncio
+async def test_admin_remove_board_master(client: AsyncClient, db_session):
+    admin_ac, _, board = await _prepare_user_and_board(
+        client, db_session, "br_admin", "admin"
+    )
+    normal_ac, user, _ = await _prepare_user_and_board(
+        client, db_session, "br_user", "user"
+    )
+    await _make_board_master(admin_ac, str(board.id), str(user.id))
+
+    resp = await admin_ac.delete(f"{ADMIN_URL}/boards/{board.id}/masters/{user.id}")
+    assert resp.status_code == status.HTTP_200_OK
+
+    # Verify removed
+    resp = await admin_ac.get(f"{ADMIN_URL}/boards/{board.id}/masters")
+    assert len(resp.json()["data"]) == 0
+
+
+@pytest.mark.asyncio
+async def test_add_board_master_duplicate_restores(client: AsyncClient, db_session):
+    admin_ac, _, board = await _prepare_user_and_board(
+        client, db_session, "bd_admin", "admin"
+    )
+    normal_ac, user, _ = await _prepare_user_and_board(
+        client, db_session, "bd_user", "user"
+    )
+    await _make_board_master(admin_ac, str(board.id), str(user.id))
+    # Remove
+    await admin_ac.delete(f"{ADMIN_URL}/boards/{board.id}/masters/{user.id}")
+    # Re-add (should restore, not fail)
+    resp = await admin_ac.post(
+        f"{ADMIN_URL}/boards/{board.id}/masters",
+        json={"user_id": str(user.id)},
+    )
+    assert resp.status_code == status.HTTP_201_CREATED
+
+
+@pytest.mark.asyncio
+async def test_non_admin_cannot_manage_masters(client: AsyncClient, db_session):
+    normal_ac, user, board = await _prepare_user_and_board(
+        client, db_session, "bn_admin", "user"
+    )
+
+    resp = await normal_ac.post(
+        f"{ADMIN_URL}/boards/{board.id}/masters",
+        json={"user_id": str(user.id)},
+    )
+    assert resp.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.asyncio
+async def test_add_board_master_nonexistent_user(client: AsyncClient, db_session):
+    admin_ac, _, board = await _prepare_user_and_board(
+        client, db_session, "bnu_admin", "admin"
+    )
+    resp = await admin_ac.post(
+        f"{ADMIN_URL}/boards/{board.id}/masters",
+        json={"user_id": str(uuid.uuid4())},
+    )
+    assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_add_board_master_nonexistent_board(client: AsyncClient, db_session):
+    admin_ac, _, _ = await _prepare_user_and_board(
+        client, db_session, "bnb_admin", "admin"
+    )
+    normal_ac, user, _ = await _prepare_user_and_board(
+        client, db_session, "bnb_user", "user"
+    )
+    resp = await admin_ac.post(
+        f"{ADMIN_URL}/boards/{uuid.uuid4()}/masters",
+        json={"user_id": str(user.id)},
+    )
+    assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+
+# =============================== Board Master Pin/Feature ===============================
+
+
+@pytest.mark.asyncio
+async def test_board_master_can_pin_post_in_their_board(
+    client: AsyncClient, db_session
+):
+    admin_ac, _, board = await _prepare_user_and_board(
+        client, db_session, "bmp_admin", "admin"
+    )
+    bm_ac, bm_user, _ = await _prepare_user_and_board(
+        client, db_session, "bmp_master", "user"
+    )
+    # Author creates post
+    author_ac, author_user, _ = await _prepare_user_and_board(
+        client, db_session, "bmp_author", "user"
+    )
+    # Make bm_master a board master
+    await _make_board_master(admin_ac, str(board.id), str(bm_user.id))
+    # Author posts in board
+    post = await _create_post(author_ac, str(board.id), "BM Pin Test")
+
+    # Board master pins it
+    resp = await bm_ac.patch(
+        f"{POSTS_URL}/{post['id']}/pin", params={"is_pinned": True}
+    )
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json()["data"]["is_pinned"] is True
+
+
+@pytest.mark.asyncio
+async def test_board_master_cannot_pin_post_in_other_board(
+    client: AsyncClient, db_session
+):
+    admin_ac, _, board_a = await _prepare_user_and_board(
+        client, db_session, "bmo_admin", "admin"
+    )
+    bm_ac, bm_user, _ = await _prepare_user_and_board(
+        client, db_session, "bmo_master", "user"
+    )
+    board_b = _create_board(db_session, "Other Board", "other-board")
+    author_ac, _, _ = await _prepare_user_and_board(
+        client, db_session, "bmo_author", "user"
+    )
+    # Make bm_master a master of board_a only
+    await _make_board_master(admin_ac, str(board_a.id), str(bm_user.id))
+    # Post in board_b (where bm_user is NOT a master)
+    post = await _create_post(author_ac, str(board_b.id), "Other Board Post")
+
+    resp = await bm_ac.patch(
+        f"{POSTS_URL}/{post['id']}/pin", params={"is_pinned": True}
+    )
+    assert resp.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.asyncio
+async def test_board_master_can_feature_post_in_their_board(
+    client: AsyncClient, db_session
+):
+    admin_ac, _, board = await _prepare_user_and_board(
+        client, db_session, "bmf_admin", "admin"
+    )
+    bm_ac, bm_user, _ = await _prepare_user_and_board(
+        client, db_session, "bmf_master", "user"
+    )
+    author_ac, _, _ = await _prepare_user_and_board(
+        client, db_session, "bmf_author", "user"
+    )
+    await _make_board_master(admin_ac, str(board.id), str(bm_user.id))
+    post = await _create_post(author_ac, str(board.id), "BM Feature Test")
+
+    resp = await bm_ac.patch(
+        f"{POSTS_URL}/{post['id']}/feature", params={"is_featured": True}
+    )
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json()["data"]["is_featured"] is True
+
+
+@pytest.mark.asyncio
+async def test_board_master_cannot_feature_post_in_other_board(
+    client: AsyncClient, db_session
+):
+    admin_ac, _, board_a = await _prepare_user_and_board(
+        client, db_session, "bmfo_admin", "admin"
+    )
+    bm_ac, bm_user, _ = await _prepare_user_and_board(
+        client, db_session, "bmfo_master", "user"
+    )
+    board_b = _create_board(db_session, "Other Board 2", "other-board-2")
+    author_ac, _, _ = await _prepare_user_and_board(
+        client, db_session, "bmfo_author", "user"
+    )
+    await _make_board_master(admin_ac, str(board_a.id), str(bm_user.id))
+    post = await _create_post(author_ac, str(board_b.id), "Other Board Post 2")
+
+    resp = await bm_ac.patch(
+        f"{POSTS_URL}/{post['id']}/feature", params={"is_featured": True}
+    )
+    assert resp.status_code == status.HTTP_403_FORBIDDEN
+
+
+# =============================== Board Master Delete ===============================
+
+
+@pytest.mark.asyncio
+async def test_board_master_can_delete_post_in_their_board(
+    client: AsyncClient, db_session
+):
+    admin_ac, _, board = await _prepare_user_and_board(
+        client, db_session, "bmd_admin", "admin"
+    )
+    bm_ac, bm_user, _ = await _prepare_user_and_board(
+        client, db_session, "bmd_master", "user"
+    )
+    author_ac, _, _ = await _prepare_user_and_board(
+        client, db_session, "bmd_author", "user"
+    )
+    await _make_board_master(admin_ac, str(board.id), str(bm_user.id))
+    post = await _create_post(author_ac, str(board.id), "BM Delete Test")
+
+    resp = await bm_ac.delete(f"{POSTS_URL}/{post['id']}")
+    assert resp.status_code == status.HTTP_200_OK
+
+
+@pytest.mark.asyncio
+async def test_board_master_cannot_delete_post_in_other_board(
+    client: AsyncClient, db_session
+):
+    admin_ac, _, board_a = await _prepare_user_and_board(
+        client, db_session, "bmdo_admin", "admin"
+    )
+    bm_ac, bm_user, _ = await _prepare_user_and_board(
+        client, db_session, "bmdo_master", "user"
+    )
+    board_b = _create_board(db_session, "Other Board 3", "other-board-3")
+    author_ac, _, _ = await _prepare_user_and_board(
+        client, db_session, "bmdo_author", "user"
+    )
+    await _make_board_master(admin_ac, str(board_a.id), str(bm_user.id))
+    post = await _create_post(author_ac, str(board_b.id), "Other Board Post 3")
+
+    resp = await bm_ac.delete(f"{POSTS_URL}/{post['id']}")
+    assert resp.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.asyncio
+async def test_regular_user_still_cannot_pin(client: AsyncClient, db_session):
+    """Regression: regular user (not board master) still cannot pin"""
+    normal_ac, _, board = await _prepare_user_and_board(
+        client, db_session, "reg_pin_user", "user"
+    )
+    post = await _create_post(normal_ac, str(board.id), "Regular Pin Test")
+
+    resp = await normal_ac.patch(
+        f"{POSTS_URL}/{post['id']}/pin", params={"is_pinned": True}
+    )
+    assert resp.status_code == status.HTTP_403_FORBIDDEN
+
+
+# =============================== Board Master Delete Comment ===============================
+
+
+@pytest.mark.asyncio
+async def test_board_master_can_delete_comment_in_their_board(
+    client: AsyncClient, db_session
+):
+    admin_ac, _, board = await _prepare_user_and_board(
+        client, db_session, "bmdc_admin", "admin"
+    )
+    bm_ac, bm_user, _ = await _prepare_user_and_board(
+        client, db_session, "bmdc_master", "user"
+    )
+    author_ac, _, _ = await _prepare_user_and_board(
+        client, db_session, "bmdc_author", "user"
+    )
+    commenter_ac, _, _ = await _prepare_user_and_board(
+        client, db_session, "bmdc_commenter", "user"
+    )
+    await _make_board_master(admin_ac, str(board.id), str(bm_user.id))
+    post = await _create_post(author_ac, str(board.id), "BM Comment Test")
+
+    # Commenter posts comment
+    resp = await commenter_ac.post(
+        COMMENTS_LIST,
+        json={"post_id": post["id"], "content": "A comment"},
+    )
+    comment_id = resp.json()["data"]["id"]
+
+    # Board master deletes it
+    resp = await bm_ac.delete(f"{COMMENTS_URL}/{comment_id}")
+    assert resp.status_code == status.HTTP_200_OK
+
+
+# =============================== Admin Mute ===============================
+
+
+@pytest.mark.asyncio
+async def test_admin_can_mute_user(client: AsyncClient, db_session):
+    admin_ac, _, _ = await _prepare_user_and_board(
+        client, db_session, "mt_admin", "admin"
+    )
+    normal_ac, user, _ = await _prepare_user_and_board(
+        client, db_session, "mt_user", "user"
+    )
+
+    resp = await admin_ac.post(
+        f"{ADMIN_URL}/users/{user.id}/mute",
+        json={"duration_minutes": 60},
+    )
+    assert resp.status_code == status.HTTP_200_OK
+    data = resp.json()["data"]
+    assert data["id"] == str(user.id)
+    # muted_until should be set
+
+
+@pytest.mark.asyncio
+async def test_admin_can_unmute_user(client: AsyncClient, db_session):
+    admin_ac, _, _ = await _prepare_user_and_board(
+        client, db_session, "umt_admin", "admin"
+    )
+    normal_ac, user, _ = await _prepare_user_and_board(
+        client, db_session, "umt_user", "user"
+    )
+    # Mute first
+    await admin_ac.post(
+        f"{ADMIN_URL}/users/{user.id}/mute",
+        json={"duration_minutes": 60},
+    )
+    # Unmute
+    resp = await admin_ac.delete(f"{ADMIN_URL}/users/{user.id}/mute")
+    assert resp.status_code == status.HTTP_200_OK
+
+
+@pytest.mark.asyncio
+async def test_muted_user_cannot_create_post(client: AsyncClient, db_session):
+    admin_ac, _, _ = await _prepare_user_and_board(
+        client, db_session, "mup_admin", "admin"
+    )
+    normal_ac, user, board = await _prepare_user_and_board(
+        client, db_session, "mup_user", "user"
+    )
+    # Mute the user
+    await admin_ac.post(
+        f"{ADMIN_URL}/users/{user.id}/mute",
+        json={"duration_minutes": 60},
+    )
+    # User tries to post
+    resp = await normal_ac.post(
+        POSTS_LIST, json={**POST_PAYLOAD, "board_id": str(board.id)}
+    )
+    assert resp.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.asyncio
+async def test_muted_user_cannot_create_comment(client: AsyncClient, db_session):
+    admin_ac, _, board = await _prepare_user_and_board(
+        client, db_session, "muc_admin", "admin"
+    )
+    author_ac, _, _ = await _prepare_user_and_board(
+        client, db_session, "muc_author", "user"
+    )
+    muted_ac, muted_user, _ = await _prepare_user_and_board(
+        client, db_session, "muc_muted", "user"
+    )
+    post = await _create_post(author_ac, str(board.id), "Mute Comment Test")
+
+    # Mute the user
+    await admin_ac.post(
+        f"{ADMIN_URL}/users/{muted_user.id}/mute",
+        json={"duration_minutes": 60},
+    )
+    # Muted user tries to comment
+    resp = await muted_ac.post(
+        COMMENTS_LIST,
+        json={"post_id": post["id"], "content": "Muted comment"},
+    )
+    assert resp.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.asyncio
+async def test_muted_user_can_still_read_posts(client: AsyncClient, db_session):
+    admin_ac, _, board = await _prepare_user_and_board(
+        client, db_session, "mur_admin", "admin"
+    )
+    author_ac, _, _ = await _prepare_user_and_board(
+        client, db_session, "mur_author", "user"
+    )
+    muted_ac, muted_user, _ = await _prepare_user_and_board(
+        client, db_session, "mur_muted", "user"
+    )
+    post = await _create_post(author_ac, str(board.id), "Readable Post")
+
+    # Mute
+    await admin_ac.post(
+        f"{ADMIN_URL}/users/{muted_user.id}/mute",
+        json={"duration_minutes": 60},
+    )
+    # Muted user can still read
+    resp = await muted_ac.get(f"{POSTS_URL}/{post['id']}")
+    assert resp.status_code == status.HTTP_200_OK
+
+    # Muted user can still list
+    resp = await muted_ac.get(POSTS_LIST)
+    assert resp.status_code == status.HTTP_200_OK
+
+
+@pytest.mark.asyncio
+async def test_board_master_can_mute_user_in_their_board(
+    client: AsyncClient, db_session
+):
+    admin_ac, _, board = await _prepare_user_and_board(
+        client, db_session, "bmm_admin", "admin"
+    )
+    bm_ac, bm_user, _ = await _prepare_user_and_board(
+        client, db_session, "bmm_master", "user"
+    )
+    target_ac, target_user, _ = await _prepare_user_and_board(
+        client, db_session, "bmm_target", "user"
+    )
+    await _make_board_master(admin_ac, str(board.id), str(bm_user.id))
+
+    resp = await bm_ac.post(
+        f"{BOARDS_URL}/{board.id}/users/{target_user.id}/mute",
+        json={"duration_minutes": 30},
+    )
+    assert resp.status_code == status.HTTP_200_OK
+
+
+@pytest.mark.asyncio
+async def test_board_master_cannot_mute_admin(client: AsyncClient, db_session):
+    admin_ac, admin_user, board = await _prepare_user_and_board(
+        client, db_session, "bmma_admin", "admin"
+    )
+    bm_ac, bm_user, _ = await _prepare_user_and_board(
+        client, db_session, "bmma_master", "user"
+    )
+    await _make_board_master(admin_ac, str(board.id), str(bm_user.id))
+
+    resp = await bm_ac.post(
+        f"{BOARDS_URL}/{board.id}/users/{admin_user.id}/mute",
+        json={"duration_minutes": 30},
+    )
+    assert resp.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.asyncio
+async def test_non_board_master_cannot_mute(client: AsyncClient, db_session):
+    admin_ac, _, board = await _prepare_user_and_board(
+        client, db_session, "nbm_admin", "admin"
+    )
+    normal_ac, _, _ = await _prepare_user_and_board(
+        client, db_session, "nbm_user", "user"
+    )
+    target_ac, target_user, _ = await _prepare_user_and_board(
+        client, db_session, "nbm_target", "user"
+    )
+
+    resp = await normal_ac.post(
+        f"{BOARDS_URL}/{board.id}/users/{target_user.id}/mute",
+        json={"duration_minutes": 30},
+    )
+    assert resp.status_code == status.HTTP_403_FORBIDDEN
+
+
+# =============================== Public Board Masters Endpoint ===============================
+
+
+@pytest.mark.asyncio
+async def test_public_can_list_board_masters(client: AsyncClient, db_session):
+    admin_ac, _, board = await _prepare_user_and_board(
+        client, db_session, "pbm_admin", "admin"
+    )
+    normal_ac, user, _ = await _prepare_user_and_board(
+        client, db_session, "pbm_user", "user"
+    )
+    await _make_board_master(admin_ac, str(board.id), str(user.id))
+
+    # Unauthenticated user can see board masters
+    resp = await client.get(f"{BOARDS_URL}/{board.id}/masters")
+    assert resp.status_code == status.HTTP_200_OK
+    data = resp.json()["data"]
+    assert len(data) == 1
+    assert data[0]["user"]["username"] == "pbm_user"
+
+
+@pytest.mark.asyncio
+async def test_list_board_masters_empty(client: AsyncClient, db_session):
+    _, _, board = await _prepare_user_and_board(client, db_session, "pbe_user", "user")
+
+    resp = await client.get(f"{BOARDS_URL}/{board.id}/masters")
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json()["data"] == []

--- a/frontend/components.d.ts
+++ b/frontend/components.d.ts
@@ -59,6 +59,7 @@ declare module 'vue' {
     PostStatusTag: typeof import('./src/components/post/PostStatusTag.vue')['default']
     RouterLink: typeof import('vue-router')['RouterLink']
     RouterView: typeof import('vue-router')['RouterView']
+    ThumbsUp: typeof import('./src/components/common/ThumbsUp.vue')['default']
     UserAvatar: typeof import('./src/components/common/UserAvatar.vue')['default']
   }
 }

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -1,6 +1,7 @@
 import httpClient from './client'
 import type { User } from '@/types/user'
 import type { PaginatedData } from '@/types/api'
+import type { BoardMasterInfo } from '@/types/board'
 
 export interface AdminStats {
   total_users: number
@@ -26,5 +27,29 @@ export const adminAPI = {
 
   updateUserStatus(userId: string, status: string): Promise<User> {
     return httpClient.patch(`/api/v1/admin/users/${userId}/status`, { status })
+  },
+
+  // Board master management
+  listBoardMasters(boardId: string): Promise<BoardMasterInfo[]> {
+    return httpClient.get(`/api/v1/admin/boards/${boardId}/masters`)
+  },
+
+  addBoardMaster(boardId: string, userId: string): Promise<BoardMasterInfo> {
+    return httpClient.post(`/api/v1/admin/boards/${boardId}/masters`, { user_id: userId })
+  },
+
+  removeBoardMaster(boardId: string, userId: string): Promise<void> {
+    return httpClient.delete(`/api/v1/admin/boards/${boardId}/masters/${userId}`)
+  },
+
+  // Mute management
+  muteUser(userId: string, durationMinutes: number): Promise<User> {
+    return httpClient.post(`/api/v1/admin/users/${userId}/mute`, {
+      duration_minutes: durationMinutes,
+    })
+  },
+
+  unmuteUser(userId: string): Promise<void> {
+    return httpClient.delete(`/api/v1/admin/users/${userId}/mute`)
   },
 }

--- a/frontend/src/api/boards.ts
+++ b/frontend/src/api/boards.ts
@@ -1,5 +1,6 @@
 import httpClient from './client'
-import type { Board, BoardCreate, BoardUpdate } from '@/types/board'
+import type { Board, BoardCreate, BoardUpdate, BoardMasterInfo } from '@/types/board'
+import type { MuteUserRequest } from '@/types/user'
 
 export const boardsAPI = {
   getBoards(): Promise<Board[]> {
@@ -20,5 +21,13 @@ export const boardsAPI = {
 
   deleteBoard(id: string): Promise<void> {
     return httpClient.delete(`/api/v1/boards/${id}`)
+  },
+
+  getBoardMasters(boardId: string): Promise<BoardMasterInfo[]> {
+    return httpClient.get(`/api/v1/boards/${boardId}/masters`)
+  },
+
+  muteUser(boardId: string, userId: string, payload: MuteUserRequest): Promise<void> {
+    return httpClient.post(`/api/v1/boards/${boardId}/users/${userId}/mute`, payload)
   },
 }

--- a/frontend/src/api/likes.ts
+++ b/frontend/src/api/likes.ts
@@ -1,5 +1,10 @@
 import httpClient from './client'
 
+export interface PostLikeStatus {
+  is_liked: boolean
+  liked_comment_ids: string[]
+}
+
 export const likesAPI = {
   likePost(postId: string): Promise<void> {
     return httpClient.post(`/api/v1/likes/posts/${postId}`)
@@ -15,5 +20,9 @@ export const likesAPI = {
 
   unlikeComment(commentId: string): Promise<void> {
     return httpClient.delete(`/api/v1/likes/comments/${commentId}`)
+  },
+
+  getMyLikeStatus(postId: string): Promise<PostLikeStatus> {
+    return httpClient.get('/api/v1/likes/my-status', { params: { post_id: postId } })
   },
 }

--- a/frontend/src/components/comment/CommentItem.vue
+++ b/frontend/src/components/comment/CommentItem.vue
@@ -17,7 +17,7 @@
         <div class="comment-actions">
           <span class="action-btn" @click="emit('toggle-like', comment.id)">
             <el-icon :size="14" :color="liked ? '#f56c6c' : undefined">
-              <StarFilled v-if="liked" /><Star v-else />
+              <ThumbsUp :filled="liked" :size="14" />
             </el-icon>
             {{ comment.like_count }}
           </span>
@@ -51,7 +51,8 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
-import { Star, StarFilled, ChatDotRound, Delete } from '@element-plus/icons-vue'
+import { ChatDotRound, Delete } from '@element-plus/icons-vue'
+import ThumbsUp from '@/components/common/ThumbsUp.vue'
 import { useAuthStore } from '@/stores/auth'
 import UserAvatar from '@/components/common/UserAvatar.vue'
 import { renderMarkdown } from '@/utils/markdown'

--- a/frontend/src/components/common/ThumbsUp.vue
+++ b/frontend/src/components/common/ThumbsUp.vue
@@ -1,0 +1,24 @@
+<template>
+  <svg
+    :width="size"
+    :height="size"
+    viewBox="0 0 24 24"
+    :fill="filled ? 'currentColor' : 'none'"
+    :stroke="filled ? 'none' : 'currentColor'"
+    stroke-width="1.5"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M7 22H4a2 2 0 0 1-2-2v-7a2 2 0 0 1 2-2h3m7-2V5a3 3 0 0 0-3-3l-4 9v11h11.28a2 2 0 0 0 2-1.7l1.38-9a2 2 0 0 0-2-2.3H14Z"
+    />
+  </svg>
+</template>
+
+<script setup lang="ts">
+withDefaults(defineProps<{ size?: number; filled?: boolean }>(), {
+  size: 16,
+  filled: false,
+})
+</script>

--- a/frontend/src/components/post/PostListItem.vue
+++ b/frontend/src/components/post/PostListItem.vue
@@ -24,7 +24,7 @@
     </div>
     <div class="post-stats">
       <span class="stat-item">
-        <el-icon :size="14"><Star /></el-icon>
+        <el-icon :size="14"><ThumbsUp /></el-icon>
         {{ post.like_count }}
       </span>
       <span class="stat-item">
@@ -37,7 +37,8 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
-import { Star, ChatDotRound } from '@element-plus/icons-vue'
+import { ChatDotRound } from '@element-plus/icons-vue'
+import ThumbsUp from '@/components/common/ThumbsUp.vue'
 import PostStatusTag from './PostStatusTag.vue'
 import UserAvatar from '@/components/common/UserAvatar.vue'
 import { formatTimeAgo } from '@/utils/format'

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -12,6 +12,10 @@ export const useAuthStore = defineStore('auth', () => {
 
   const isAuthenticated = computed(() => !!token.value)
   const isAdmin = computed(() => currentUser.value?.role === 'admin')
+  const isMuted = computed(() => {
+    if (!currentUser.value?.muted_until) return false
+    return new Date(currentUser.value.muted_until) > new Date()
+  })
 
   async function login(payload: LoginRequest) {
     loading.value = true
@@ -21,8 +25,13 @@ export const useAuthStore = defineStore('auth', () => {
       token.value = data.access_token
       await fetchProfile()
       return true
-    } catch {
-      return false
+    } catch (err) {
+      // Clean up any partially-set state on failure
+      if (token.value) {
+        removeToken()
+        token.value = null
+      }
+      throw err
     } finally {
       loading.value = false
     }
@@ -78,6 +87,7 @@ export const useAuthStore = defineStore('auth', () => {
     loading,
     isAuthenticated,
     isAdmin,
+    isMuted,
     login,
     register,
     logout,

--- a/frontend/src/stores/posts.ts
+++ b/frontend/src/stores/posts.ts
@@ -57,6 +57,7 @@ export const usePostStore = defineStore('posts', () => {
   async function deletePost(id: string) {
     await postsAPI.deletePost(id)
     postList.value = postList.value.filter((p) => p.id !== id)
+    if (pagination.total > 0) pagination.total--
     if (currentPost.value?.id === id) currentPost.value = null
   }
 
@@ -65,6 +66,14 @@ export const usePostStore = defineStore('posts', () => {
     if (post) post.like_count = Math.max(0, post.like_count + delta)
     if (currentPost.value?.id === postId) {
       currentPost.value.like_count = Math.max(0, currentPost.value.like_count + delta)
+    }
+  }
+
+  function updateCommentCount(postId: string, delta: number) {
+    const post = postList.value.find((p) => p.id === postId)
+    if (post) post.comment_count = Math.max(0, post.comment_count + delta)
+    if (currentPost.value?.id === postId) {
+      currentPost.value.comment_count = Math.max(0, currentPost.value.comment_count + delta)
     }
   }
 
@@ -79,5 +88,6 @@ export const usePostStore = defineStore('posts', () => {
     updatePost,
     deletePost,
     updateLikeCount,
+    updateCommentCount,
   }
 })

--- a/frontend/src/types/board.ts
+++ b/frontend/src/types/board.ts
@@ -21,3 +21,18 @@ export interface BoardUpdate {
   description?: string
   sort_order?: number
 }
+
+export interface BoardMasterUserInfo {
+  id: string
+  username: string
+  nickname?: string
+  avatar_url?: string
+}
+
+export interface BoardMasterInfo {
+  id: string
+  board_id: string
+  user_id: string
+  user: BoardMasterUserInfo
+  created_at: string
+}

--- a/frontend/src/types/user.ts
+++ b/frontend/src/types/user.ts
@@ -9,6 +9,7 @@ export interface User {
   avatar_url?: string
   role: UserRole
   status: UserStatus
+  muted_until?: string | null
   last_login_at?: string
   created_at: string
   updated_at: string
@@ -51,4 +52,8 @@ export interface VerifyEmailData {
 
 export interface ResendVerifyRequest {
   email: string
+}
+
+export interface MuteUserRequest {
+  duration_minutes: number
 }

--- a/frontend/src/views/admin/AdminBoardsView.vue
+++ b/frontend/src/views/admin/AdminBoardsView.vue
@@ -18,10 +18,13 @@
           </template>
         </el-table-column>
         <el-table-column prop="sort_order" label="排序" width="70" />
-        <el-table-column label="操作" width="200">
+        <el-table-column label="操作" min-width="320">
           <template #default="{ row }">
             <el-button size="small" @click="openEditDialog(row)">编辑</el-button>
             <el-button size="small" type="danger" @click="handleDelete(row)">删除</el-button>
+            <el-button size="small" type="warning" @click="openMastersDialog(row)"
+              >管理版主</el-button
+            >
           </template>
         </el-table-column>
       </el-table>
@@ -54,6 +57,69 @@
         </el-button>
       </template>
     </el-dialog>
+
+    <!-- Board Masters Dialog -->
+    <el-dialog
+      v-model="mastersDialogVisible"
+      :title="`管理版主 — ${mastersTargetBoard?.name || ''}`"
+      width="520px"
+    >
+      <LoadingSkeleton v-if="mastersLoading" type="table-row" :count="3" />
+      <div v-else>
+        <p v-if="!boardMasters.length" style="color: var(--color-text-secondary)">暂无版主</p>
+        <el-table v-else :data="boardMasters" size="small">
+          <el-table-column label="用户名" prop="user.username" />
+          <el-table-column label="昵称">
+            <template #default="{ row }">
+              {{ row.user.nickname || '-' }}
+            </template>
+          </el-table-column>
+          <el-table-column label="操作" width="80">
+            <template #default="{ row }">
+              <el-button size="small" type="danger" @click="handleRemoveMaster(row.user_id)">
+                移除
+              </el-button>
+            </template>
+          </el-table-column>
+        </el-table>
+
+        <el-divider />
+        <div class="add-master-row">
+          <el-select
+            v-model="selectedUserId"
+            filterable
+            remote
+            reserve-keyword
+            :remote-method="searchUsers"
+            :loading="searchingUsers"
+            placeholder="搜索用户名或邮箱"
+            style="flex: 1"
+            clearable
+          >
+            <el-option
+              v-for="u in searchedUsers"
+              :key="u.id"
+              :label="`${u.username}${u.nickname ? ' (' + u.nickname + ')' : ''} — ${u.email}`"
+              :value="u.id"
+            >
+              <div class="user-option">
+                <span class="user-option-name">{{ u.username }}</span>
+                <span v-if="u.nickname" class="user-option-nick">({{ u.nickname }})</span>
+                <span class="user-option-email">{{ u.email }}</span>
+              </div>
+            </el-option>
+          </el-select>
+          <el-button
+            type="primary"
+            :loading="addingMaster"
+            :disabled="!selectedUserId"
+            @click="handleAddMaster"
+          >
+            添加
+          </el-button>
+        </div>
+      </div>
+    </el-dialog>
   </div>
 </template>
 
@@ -61,11 +127,13 @@
 import { ref, reactive, onMounted } from 'vue'
 import { ElMessage, ElMessageBox } from 'element-plus'
 import { boardsAPI } from '@/api/boards'
+import { adminAPI } from '@/api/admin'
 
 import LoadingSkeleton from '@/components/common/LoadingSkeleton.vue'
 import ErrorState from '@/components/common/ErrorState.vue'
 import EmptyState from '@/components/common/EmptyState.vue'
-import type { Board } from '@/types/board'
+import type { Board, BoardMasterInfo } from '@/types/board'
+import type { User } from '@/types/user'
 
 const boards = ref<Board[]>([])
 const loading = ref(false)
@@ -157,6 +225,84 @@ async function handleDelete(board: Board) {
   }
 }
 
+// Board Master Management
+const mastersDialogVisible = ref(false)
+const mastersTargetBoard = ref<Board | null>(null)
+const boardMasters = ref<BoardMasterInfo[]>([])
+const mastersLoading = ref(false)
+const selectedUserId = ref<string | null>(null)
+const searchedUsers = ref<User[]>([])
+const searchingUsers = ref(false)
+const addingMaster = ref(false)
+
+async function openMastersDialog(board: Board) {
+  mastersTargetBoard.value = board
+  selectedUserId.value = null
+  searchedUsers.value = []
+  mastersDialogVisible.value = true
+  await fetchBoardMasters()
+}
+
+async function fetchBoardMasters() {
+  if (!mastersTargetBoard.value) return
+  mastersLoading.value = true
+  try {
+    boardMasters.value = await adminAPI.listBoardMasters(mastersTargetBoard.value.id)
+  } catch {
+    ElMessage.error('加载版主列表失败')
+  } finally {
+    mastersLoading.value = false
+  }
+}
+
+async function searchUsers(query: string) {
+  if (!query || query.length < 1) {
+    searchedUsers.value = []
+    return
+  }
+  searchingUsers.value = true
+  try {
+    const result = await adminAPI.listUsers({ search: query, page_size: 20 })
+    // Exclude users who are already board masters
+    const existingIds = new Set(boardMasters.value.map((bm) => bm.user_id))
+    searchedUsers.value = result.items.filter((u) => !existingIds.has(u.id))
+  } catch {
+    searchedUsers.value = []
+  } finally {
+    searchingUsers.value = false
+  }
+}
+
+async function handleAddMaster() {
+  if (!mastersTargetBoard.value || !selectedUserId.value) {
+    ElMessage.warning('请选择用户')
+    return
+  }
+  addingMaster.value = true
+  try {
+    await adminAPI.addBoardMaster(mastersTargetBoard.value.id, selectedUserId.value)
+    ElMessage.success('已添加版主')
+    selectedUserId.value = null
+    searchedUsers.value = []
+    await fetchBoardMasters()
+  } catch {
+    ElMessage.error('添加失败')
+  } finally {
+    addingMaster.value = false
+  }
+}
+
+async function handleRemoveMaster(userId: string) {
+  if (!mastersTargetBoard.value) return
+  try {
+    await adminAPI.removeBoardMaster(mastersTargetBoard.value.id, userId)
+    ElMessage.success('已移除版主')
+    boardMasters.value = boardMasters.value.filter((bm) => bm.user_id !== userId)
+  } catch {
+    ElMessage.error('移除失败')
+  }
+}
+
 onMounted(() => fetchBoards())
 </script>
 
@@ -177,5 +323,32 @@ onMounted(() => fetchBoards())
 
 .page-toolbar h1 {
   margin-bottom: 0;
+}
+
+.add-master-row {
+  display: flex;
+  gap: var(--spacing-sm);
+  align-items: center;
+}
+
+.user-option {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.user-option-name {
+  font-weight: 500;
+}
+
+.user-option-nick {
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-xs);
+}
+
+.user-option-email {
+  color: var(--color-text-placeholder);
+  font-size: var(--font-size-xs);
+  margin-left: auto;
 }
 </style>

--- a/frontend/src/views/admin/AdminUsersView.vue
+++ b/frontend/src/views/admin/AdminUsersView.vue
@@ -37,7 +37,7 @@
             </el-tag>
           </template>
         </el-table-column>
-        <el-table-column label="操作" width="160">
+        <el-table-column label="操作" width="260">
           <template #default="{ row }">
             <el-button
               v-if="row.status === 'active'"
@@ -55,6 +55,12 @@
             >
               解封
             </el-button>
+            <template v-if="isUserMuted(row)">
+              <el-button size="small" type="info" @click="handleUnmute(row)"> 解除禁言 </el-button>
+            </template>
+            <template v-else>
+              <el-button size="small" type="warning" @click="openMuteDialog(row)"> 禁言 </el-button>
+            </template>
           </template>
         </el-table-column>
       </el-table>
@@ -67,6 +73,30 @@
         @page-change="(p: number) => fetchUsers(p)"
       />
     </div>
+
+    <!-- Mute Dialog -->
+    <el-dialog v-model="muteDialogVisible" title="禁言用户" width="420px">
+      <p style="margin-bottom: 16px">
+        将用户 <strong>{{ muteTarget?.nickname || muteTarget?.username }}</strong> 禁言
+      </p>
+      <div class="mute-presets">
+        <el-button
+          v-for="preset in MUTE_PRESETS"
+          :key="preset.label"
+          :type="muteDuration === preset.minutes ? 'primary' : ''"
+          @click="muteDuration = preset.minutes"
+        >
+          {{ preset.label }}
+        </el-button>
+      </div>
+      <el-form-item label="自定义时长（分钟）" style="margin-top: 16px">
+        <el-input-number v-model="muteDuration" :min="1" :max="43200" />
+      </el-form-item>
+      <template #footer>
+        <el-button @click="muteDialogVisible = false">取消</el-button>
+        <el-button type="primary" :loading="muting" @click="handleMute"> 确认禁言 </el-button>
+      </template>
+    </el-dialog>
   </div>
 </template>
 
@@ -82,6 +112,14 @@ import ErrorState from '@/components/common/ErrorState.vue'
 import EmptyState from '@/components/common/EmptyState.vue'
 import type { User } from '@/types/user'
 
+const MUTE_PRESETS = [
+  { label: '10分钟', minutes: 10 },
+  { label: '1小时', minutes: 60 },
+  { label: '6小时', minutes: 360 },
+  { label: '24小时', minutes: 1440 },
+  { label: '7天', minutes: 10080 },
+]
+
 const users = ref<User[]>([])
 const loading = ref(false)
 const error = ref<string | null>(null)
@@ -91,6 +129,10 @@ const pagination = reactive({
   pageSize: DEFAULT_PAGE_SIZE,
   total: 0,
 })
+const muteDialogVisible = ref(false)
+const muteTarget = ref<User | null>(null)
+const muteDuration = ref(60)
+const muting = ref(false)
 
 async function fetchUsers(page = 1) {
   loading.value = true
@@ -127,6 +169,47 @@ async function handleActivate(userId: string) {
   ElMessage.success('已解封')
   const u = users.value.find((u) => u.id === userId)
   if (u) u.status = 'active'
+}
+
+function isUserMuted(user: User): boolean {
+  if (!user.muted_until) return false
+  return new Date(user.muted_until) > new Date()
+}
+
+function openMuteDialog(user: User) {
+  muteTarget.value = user
+  muteDuration.value = 60
+  muteDialogVisible.value = true
+}
+
+async function handleMute() {
+  if (!muteTarget.value) return
+  muting.value = true
+  try {
+    await adminAPI.muteUser(muteTarget.value.id, muteDuration.value)
+    ElMessage.success('已禁言')
+    muteDialogVisible.value = false
+    const u = users.value.find((u) => u.id === muteTarget.value!.id)
+    if (u) {
+      const until = new Date(Date.now() + muteDuration.value * 60000)
+      u.muted_until = until.toISOString()
+    }
+  } catch {
+    ElMessage.error('禁言失败')
+  } finally {
+    muting.value = false
+  }
+}
+
+async function handleUnmute(user: User) {
+  try {
+    await adminAPI.unmuteUser(user.id)
+    ElMessage.success('已解除禁言')
+    const u = users.value.find((u) => u.id === user.id)
+    if (u) u.muted_until = null
+  } catch {
+    ElMessage.error('操作失败')
+  }
 }
 
 onMounted(() => fetchUsers())

--- a/frontend/src/views/auth/LoginView.vue
+++ b/frontend/src/views/auth/LoginView.vue
@@ -155,6 +155,8 @@ async function handleLogin() {
       lastLoginAccount.value = loginForm.account
       resendEmail.value = loginForm.account.includes('@') ? loginForm.account : ''
       resendDialogVisible.value = true
+    } else if (detail.includes('banned') || detail.includes('inactive')) {
+      ElMessage.error('账号已被封禁，无法登录')
     } else {
       ElMessage.error('账号或密码错误')
     }

--- a/frontend/src/views/auth/ResetPasswordView.vue
+++ b/frontend/src/views/auth/ResetPasswordView.vue
@@ -76,8 +76,14 @@ async function handleSubmit() {
     ElMessage.success('密码修改成功，请重新登录')
     await authStore.logout()
     router.push('/login')
-  } catch {
-    ElMessage.error('密码修改失败')
+  } catch (err: unknown) {
+    const e = err as { response?: { data?: { detail?: string } } }
+    const detail: string = e.response?.data?.detail || ''
+    if (detail) {
+      errors.new = detail
+    } else {
+      ElMessage.error('密码修改失败')
+    }
   } finally {
     submitting.value = false
   }

--- a/frontend/src/views/board/BoardPostsView.vue
+++ b/frontend/src/views/board/BoardPostsView.vue
@@ -9,8 +9,25 @@
 
       <!-- Board Info -->
       <div class="board-info">
-        <h1>{{ boardName }}</h1>
+        <h1>
+          {{ boardName }}
+          <el-tag v-if="isBoardMasterHere" type="warning" size="small" class="bm-badge"
+            >版主</el-tag
+          >
+        </h1>
         <p v-if="boardDesc">{{ boardDesc }}</p>
+        <!-- Board Masters -->
+        <div v-if="boardMasters.length" class="board-masters">
+          <span class="masters-label">版主：</span>
+          <span v-for="bm in boardMasters" :key="bm.id" class="master-item">
+            <UserAvatar
+              :src="bm.user.avatar_url"
+              :name="bm.user.nickname || bm.user.username"
+              :size="18"
+            />
+            <span class="master-name">{{ bm.user.nickname || bm.user.username }}</span>
+          </span>
+        </div>
       </div>
 
       <!-- Toolbar -->
@@ -71,17 +88,20 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { Plus } from '@element-plus/icons-vue'
 import { usePostStore } from '@/stores/posts'
 import { useBoardStore } from '@/stores/boards'
 import { useAuthStore } from '@/stores/auth'
+import { boardsAPI } from '@/api/boards'
 import PostListItem from '@/components/post/PostListItem.vue'
 import PaginationBar from '@/components/common/PaginationBar.vue'
 import LoadingSkeleton from '@/components/common/LoadingSkeleton.vue'
 import ErrorState from '@/components/common/ErrorState.vue'
 import EmptyState from '@/components/common/EmptyState.vue'
+import UserAvatar from '@/components/common/UserAvatar.vue'
+import type { BoardMasterInfo } from '@/types/board'
 
 const route = useRoute()
 const router = useRouter()
@@ -95,6 +115,13 @@ const sortBy = ref('created_at')
 const slug = route.params.slug as string
 const boardName = ref(slug || '')
 const boardDesc = ref('')
+const boardId = ref<string | null>(null)
+const boardMasters = ref<BoardMasterInfo[]>([])
+
+const isBoardMasterHere = computed(() => {
+  if (!authStore.currentUser?.id) return false
+  return boardMasters.value.some((bm) => bm.user_id === authStore.currentUser!.id)
+})
 
 async function fetchPosts(page = 1, pageSize = 20) {
   loading.value = true
@@ -110,8 +137,12 @@ async function fetchPosts(page = 1, pageSize = 20) {
     }
     boardName.value = board.name
     boardDesc.value = board.description || ''
+    boardId.value = board.id
 
-    await postStore.fetchPosts({ board_id: board.id, page, page_size: pageSize })
+    await Promise.all([
+      postStore.fetchPosts({ board_id: board.id, page, page_size: pageSize }),
+      fetchBoardMasters(board.id),
+    ])
   } catch {
     error.value = '加载帖子失败'
   } finally {
@@ -121,6 +152,14 @@ async function fetchPosts(page = 1, pageSize = 20) {
 
 function goToPost(postId: string) {
   router.push(`/posts/${postId}`)
+}
+
+async function fetchBoardMasters(id: string) {
+  try {
+    boardMasters.value = await boardsAPI.getBoardMasters(id)
+  } catch {
+    boardMasters.value = []
+  }
 }
 
 onMounted(() => {
@@ -152,6 +191,35 @@ onMounted(() => {
 
 .board-info p {
   font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+}
+
+.bm-badge {
+  vertical-align: middle;
+}
+
+.board-masters {
+  margin-top: var(--spacing-sm);
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  flex-wrap: wrap;
+}
+
+.masters-label {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+}
+
+.master-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  font-size: var(--font-size-xs);
+  color: var(--color-text-regular);
+}
+
+.master-name {
   color: var(--color-text-secondary);
 }
 

--- a/frontend/src/views/post/PostDetailView.vue
+++ b/frontend/src/views/post/PostDetailView.vue
@@ -30,18 +30,18 @@
           </div>
         </div>
 
-        <!-- Author/Admin actions -->
-        <div class="post-actions" v-if="canEdit">
+        <!-- Author/Admin/BoardMaster actions -->
+        <div class="post-actions" v-if="canEdit || canDelete || authStore.isAdmin || canModerate">
           <el-button v-if="isAuthor" size="small" @click="$router.push(`/posts/${post.id}/edit`)">
             <el-icon><Edit /></el-icon>编辑
           </el-button>
-          <el-button v-if="isAuthor" size="small" type="danger" @click="confirmDelete">
+          <el-button v-if="canDelete" size="small" type="danger" @click="confirmDelete">
             <el-icon><Delete /></el-icon>删除
           </el-button>
-          <el-button v-if="authStore.isAdmin" size="small" @click="togglePin">
+          <el-button v-if="authStore.isAdmin || canModerate" size="small" @click="togglePin">
             {{ post.is_pinned ? '取消置顶' : '置顶' }}
           </el-button>
-          <el-button v-if="authStore.isAdmin" size="small" @click="toggleFeature">
+          <el-button v-if="authStore.isAdmin || canModerate" size="small" @click="toggleFeature">
             {{ post.is_featured ? '取消加精' : '加精' }}
           </el-button>
         </div>
@@ -56,7 +56,7 @@
         <!-- Interaction bar -->
         <div class="interaction-bar">
           <el-button :type="liked ? 'danger' : 'default'" @click="handleLike">
-            <el-icon><StarFilled v-if="liked" /><Star v-else /></el-icon>
+            <el-icon><ThumbsUp :filled="liked" :size="16" /></el-icon>
             {{ post.like_count }}
           </el-button>
           <span class="interaction-stat">
@@ -82,11 +82,18 @@
         <!-- Comment Form -->
         <div class="comment-input-area">
           <template v-if="authStore.isAuthenticated">
-            <CommentForm
-              :reply-to="replyTo"
-              :on-submit="handleCommentSubmit"
-              @cancel="cancelReply"
-            />
+            <template v-if="authStore.isMuted">
+              <el-alert type="warning" :closable="false" show-icon>
+                您已被禁言，暂时无法评论
+              </el-alert>
+            </template>
+            <template v-else>
+              <CommentForm
+                :reply-to="replyTo"
+                :on-submit="handleCommentSubmit"
+                @cancel="cancelReply"
+              />
+            </template>
           </template>
           <div v-else class="login-prompt">
             <el-alert type="info" :closable="false" show-icon>
@@ -103,13 +110,15 @@
 import { ref, computed, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { ElMessage, ElMessageBox } from 'element-plus'
-import { Edit, Delete, Star, StarFilled, ChatDotRound } from '@element-plus/icons-vue'
+import { Edit, Delete, ChatDotRound } from '@element-plus/icons-vue'
+import ThumbsUp from '@/components/common/ThumbsUp.vue'
 import { renderMarkdown } from '@/utils/markdown'
 import { usePostStore } from '@/stores/posts'
 import { useAuthStore } from '@/stores/auth'
 import { postsAPI } from '@/api/posts'
 import { likesAPI } from '@/api/likes'
 import { commentsAPI } from '@/api/comments'
+import { boardsAPI } from '@/api/boards'
 import PostStatusTag from '@/components/post/PostStatusTag.vue'
 import UserAvatar from '@/components/common/UserAvatar.vue'
 import CommentTree from '@/components/comment/CommentTree.vue'
@@ -134,7 +143,9 @@ const post = computed(() => postStore.currentPost)
 const isAuthor = computed(() => {
   return authStore.currentUser?.id && post.value?.author?.id === authStore.currentUser.id
 })
+const canModerate = ref(false)
 const canEdit = computed(() => isAuthor.value || authStore.isAdmin)
+const canDelete = computed(() => isAuthor.value || authStore.isAdmin || canModerate.value)
 
 const backRoute = computed(() => {
   if (post.value?.board_id) return { name: 'Home' }
@@ -146,6 +157,15 @@ async function loadPost() {
   error.value = null
   try {
     await postStore.fetchPostById(route.params.id as string)
+    // Check if current user is a board master of this post's board
+    if (post.value?.board_id && authStore.currentUser?.id) {
+      try {
+        const masters = await boardsAPI.getBoardMasters(post.value.board_id)
+        canModerate.value = masters.some((m) => m.user_id === authStore.currentUser!.id)
+      } catch {
+        canModerate.value = false
+      }
+    }
   } catch {
     error.value = '加载帖子失败'
   } finally {
@@ -219,8 +239,17 @@ const replyToCommentId = ref<string | null>(null)
 async function loadComments() {
   commentsLoading.value = true
   try {
-    const data = await commentsAPI.getComments(route.params.id as string)
-    comments.value = data.items
+    const [commentData, likeStatus] = await Promise.all([
+      commentsAPI.getComments(route.params.id as string),
+      authStore.isAuthenticated
+        ? likesAPI.getMyLikeStatus(route.params.id as string).catch(() => null)
+        : Promise.resolve(null),
+    ])
+    comments.value = commentData.items
+    if (likeStatus) {
+      liked.value = likeStatus.is_liked
+      likedComments.value = new Set(likeStatus.liked_comment_ids)
+    }
   } catch {
     /* silent */
   } finally {
@@ -247,6 +276,7 @@ async function handleCommentSubmit(content: string) {
     ElMessage.success('评论成功')
     replyTo.value = ''
     replyToCommentId.value = null
+    postStore.updateCommentCount(post.value!.id, 1)
     await loadComments()
   } catch {
     ElMessage.error('评论失败')
@@ -262,10 +292,28 @@ async function handleCommentDelete(commentId: string) {
     })
     await commentsAPI.deleteComment(commentId)
     ElMessage.success('已删除')
+    postStore.updateCommentCount(post.value!.id, -1)
     await loadComments()
   } catch {
     /* canceled */
   }
+}
+
+function updateCommentLikeCount(
+  commentList: CommentRead[],
+  commentId: string,
+  delta: number,
+): boolean {
+  for (const c of commentList) {
+    if (c.id === commentId) {
+      c.like_count = Math.max(0, c.like_count + delta)
+      return true
+    }
+    if (c.replies?.length && updateCommentLikeCount(c.replies, commentId, delta)) {
+      return true
+    }
+  }
+  return false
 }
 
 async function handleCommentLike(commentId: string) {
@@ -273,9 +321,11 @@ async function handleCommentLike(commentId: string) {
     if (likedComments.value.has(commentId)) {
       await likesAPI.unlikeComment(commentId)
       likedComments.value.delete(commentId)
+      updateCommentLikeCount(comments.value, commentId, -1)
     } else {
       await likesAPI.likeComment(commentId)
       likedComments.value.add(commentId)
+      updateCommentLikeCount(comments.value, commentId, 1)
     }
   } catch {
     ElMessage.error('操作失败')


### PR DESCRIPTION
  ## Summary

  新增版主（board_master）角色实现细粒度权限管理，添加用户禁言功能，并修复多个认证和交互 bug。

  ## Changes

  ### 新功能
  - **版主系统** — 新增 `board_masters` 关联表，管理员可为板块指派版主，版主可在管辖板块内置顶、加精、删帖
  - **用户禁言** — 管理员/版主可为用户设置禁言时长，禁言期间无法发帖和评论
  - **点赞状态持久化** — 新增 `GET /likes/my-status` 接口，刷新页面后恢复点赞状态

  ### Bug 修复
  - 密码错误时不再显示"登录成功"
  - 板块帖子数不再始终为 0
  - 评论点赞数实时更新
  - 封禁用户登录时显示"账号已封禁"而非"账号或密码错误"
  - 修改密码时禁止新旧密码相同

  ### UX 改进
  - 点赞图标由 ⭐ 改为 👍 大拇指
  - 添加版主从 UUID 输入框改为用户名搜索下拉框
  - 重置密码页面显示具体错误信息