### PR TITLE
Feat/nested reply avatar crop 0609

### DIFF
--- a/backend/app/storage/factory.py
+++ b/backend/app/storage/factory.py
@@ -1,13 +1,21 @@
+import logging
 from functools import lru_cache
 
 from app.config import Settings
 from app.config import get_settings
+from app.storage.base import StorageBackend
+from app.storage.memory import InMemoryStorageBackend
 from app.storage.s3 import S3StorageBackend
+
+logger = logging.getLogger(__name__)
 
 
 @lru_cache
-def get_storage_backend(settings: Settings | None = None) -> S3StorageBackend:
+def get_storage_backend(settings: Settings | None = None) -> StorageBackend:
     settings = settings or get_settings()
+    if not settings.S3_ACCESS_KEY_ID or not settings.S3_SECRET_ACCESS_KEY:
+        logger.warning("S3 credentials not configured — using in-memory storage (dev only)")
+        return InMemoryStorageBackend()
     return S3StorageBackend(
         endpoint_url=settings.S3_ENDPOINT_URL,
         access_key_id=settings.S3_ACCESS_KEY_ID,

--- a/backend/app/storage/factory.py
+++ b/backend/app/storage/factory.py
@@ -14,7 +14,9 @@ logger = logging.getLogger(__name__)
 def get_storage_backend(settings: Settings | None = None) -> StorageBackend:
     settings = settings or get_settings()
     if not settings.S3_ACCESS_KEY_ID or not settings.S3_SECRET_ACCESS_KEY:
-        logger.warning("S3 credentials not configured — using in-memory storage (dev only)")
+        logger.warning(
+            "S3 credentials not configured — using in-memory storage (dev only)"
+        )
         return InMemoryStorageBackend()
     return S3StorageBackend(
         endpoint_url=settings.S3_ENDPOINT_URL,

--- a/frontend/components.d.ts
+++ b/frontend/components.d.ts
@@ -15,6 +15,7 @@ declare module 'vue' {
     AdminStatsCard: typeof import('./src/components/admin/AdminStatsCard.vue')['default']
     AppFooter: typeof import('./src/components/common/AppFooter.vue')['default']
     AppHeader: typeof import('./src/components/common/AppHeader.vue')['default']
+    AvatarCropDialog: typeof import('./src/components/common/AvatarCropDialog.vue')['default']
     BoardCard: typeof import('./src/components/board/BoardCard.vue')['default']
     BoardSelector: typeof import('./src/components/board/BoardSelector.vue')['default']
     CommentForm: typeof import('./src/components/comment/CommentForm.vue')['default']

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     "@element-plus/icons-vue": "^2.3.2",
     "@vueuse/core": "^14.3.0",
     "axios": "^1.16.1",
+    "cropperjs": "^1.6.2",
     "dompurify": "^3.4.5",
     "element-plus": "^2.14.0",
     "katex": "^0.17.0",
@@ -32,6 +33,7 @@
   },
   "devDependencies": {
     "@tsconfig/node24": "^24.0.4",
+    "@types/cropperjs": "^1.3.3",
     "@types/dompurify": "^3.2.0",
     "@types/jsdom": "^28.0.1",
     "@types/markdown-it": "^14.1.2",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       axios:
         specifier: ^1.16.1
         version: 1.16.1
+      cropperjs:
+        specifier: ^1.6.2
+        version: 1.6.2
       dompurify:
         specifier: ^3.4.5
         version: 3.4.5
@@ -51,6 +54,9 @@ importers:
       '@tsconfig/node24':
         specifier: ^24.0.4
         version: 24.0.4
+      '@types/cropperjs':
+        specifier: ^1.3.3
+        version: 1.3.3
       '@types/dompurify':
         specifier: ^3.2.0
         version: 3.2.0
@@ -677,56 +683,48 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-arm64-musl@1.60.0':
     resolution: {integrity: sha512-eDYDXZGhQAXyn6GwtwiX/qcLS0HlOLPJ/+iiIY8RYr+3P8oKBmgKxADLlniL6FtWfE7pPk7IGN9/xvDEvDvFeg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxlint/binding-linux-ppc64-gnu@1.60.0':
     resolution: {integrity: sha512-nxehly5XYBHUWI9VJX1bqCf9j/B43DaK/aS/T1fcxCpX3PA4Rm9BB54nPD1CKayT8xg6REN1ao+01hSRNgy8OA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-gnu@1.60.0':
     resolution: {integrity: sha512-j1qf/NaUfOWQutjeoooNG1Q0zsK0XGmSu1uDLq3cctquRF3j7t9Hxqf/76ehCc5GEUAanth2W4Fa+XT1RFg/nw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-musl@1.60.0':
     resolution: {integrity: sha512-YELKPRefQ/q/h3RUmeRfPCUhh2wBvgV1RyZ/F9M9u8cDyXsQW2ojv1DeWQTt466yczDITjZnIOg/s05pk7Ve2A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxlint/binding-linux-s390x-gnu@1.60.0':
     resolution: {integrity: sha512-JkO3C6Gki7Y6h/MiIkFKvHFOz98/YWvQ4WYbK9DLXACMP2rjULzkeGyAzorJE5S1dzLQGFgeqvN779kSFwoV1g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-x64-gnu@1.60.0':
     resolution: {integrity: sha512-XjKHdFVCpZZZSWBCKyyqCq65s2AKXykMXkjLoKYODrD+f5toLhlwsMESscu8FbgnJQ4Y/dpR/zdazsahmgBJIA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-x64-musl@1.60.0':
     resolution: {integrity: sha512-js29ZWIuPhNWzY8NC7KoffEMEeWG105vbmm+8EOJsC+T/jHBiKIJEUF78+F/IrgEWMMP9N0kRND4Pp75+xAhKg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxlint/binding-openharmony-arm64@1.60.0':
     resolution: {integrity: sha512-H+PUITKHk04stFpWj3x3Kg08Afp/bcXSBi0EhasR5a0Vw7StXHTzdl655PUI0fB4qdh2Wsu6Dsi+3ACxPoyQnA==}
@@ -781,42 +779,36 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.6':
     resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.6':
     resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.6':
     resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.6':
     resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.6':
     resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.6':
     resolution: {integrity: sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==}
@@ -882,42 +874,36 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.1':
     resolution: {integrity: sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.1':
     resolution: {integrity: sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.1':
     resolution: {integrity: sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.1':
     resolution: {integrity: sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.1':
     resolution: {integrity: sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.1':
     resolution: {integrity: sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ==}
@@ -959,6 +945,10 @@ packages:
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/cropperjs@1.3.3':
+    resolution: {integrity: sha512-xpX516HBzuFpvprQAB+djtV89eYBGhN8Hxw5jM2DPVW6VMmxW1y2keOcna2sKhlFO+QlqpzaJOINQGvX8ai5WQ==}
+    deprecated: This is a stub types definition. cropperjs provides its own type definitions, so you do not need this installed.
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
@@ -1432,6 +1422,9 @@ packages:
 
   crelt@1.0.6:
     resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
+
+  cropperjs@1.6.2:
+    resolution: {integrity: sha512-nhymn9GdnV3CqiEHJVai54TULFAE3VshJTXSqSJKa8yXAKyBKDWdhHarnlIPrshJ0WMFTGuFvG02YjLXfPiuOA==}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -1944,28 +1937,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -3706,6 +3695,10 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/cropperjs@1.3.3':
+    dependencies:
+      cropperjs: 1.6.2
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/dompurify@3.2.0':
@@ -4266,6 +4259,8 @@ snapshots:
       is-what: 5.5.0
 
   crelt@1.0.6: {}
+
+  cropperjs@1.6.2: {}
 
   cross-spawn@7.0.6:
     dependencies:

--- a/frontend/src/components/comment/CommentItem.vue
+++ b/frontend/src/components/comment/CommentItem.vue
@@ -11,6 +11,9 @@
           <span class="comment-author">{{
             comment.author?.nickname || comment.author?.username
           }}</span>
+          <span v-if="parentAuthorName" class="reply-target">
+            回复 <span class="reply-target-name">@{{ parentAuthorName }}</span>
+          </span>
           <span class="comment-time">{{ formatTimeAgo(comment.created_at) }}</span>
         </div>
         <div class="comment-content markdown-body" v-html="renderMarkdown(comment.content)" />
@@ -22,7 +25,6 @@
             {{ comment.like_count }}
           </span>
           <span
-            v-if="depth === 0"
             class="action-btn"
             @click="emit('reply', comment.id, comment.author?.nickname || comment.author?.username)"
           >
@@ -39,6 +41,7 @@
             :comment="child"
             :depth="depth + 1"
             :liked-set="likedSet"
+            :parent-author-name="replyAuthorMap[child.parent_comment_id ?? '']"
             @reply="(id: string, name: string) => emit('reply', id, name)"
             @toggle-like="(id: string) => emit('toggle-like', id)"
             @delete="(id: string) => emit('delete', id)"
@@ -64,10 +67,12 @@ const props = withDefaults(
     comment: CommentRead
     depth?: number
     likedSet?: Set<string>
+    parentAuthorName?: string
   }>(),
   {
     depth: 0,
     likedSet: () => new Set(),
+    parentAuthorName: undefined,
   },
 )
 
@@ -83,6 +88,17 @@ const liked = computed(() => props.likedSet.has(props.comment.id))
 const canDelete = computed(
   () => authStore.currentUser?.id === props.comment.author?.id || authStore.isAdmin,
 )
+
+// Build a map of reply id -> author name for all children, so nested replies can show @mention
+const replyAuthorMap = computed<Record<string, string>>(() => {
+  const map: Record<string, string> = {}
+  // Include the root comment itself
+  map[props.comment.id] = props.comment.author?.nickname || props.comment.author?.username || ''
+  for (const r of props.comment.replies ?? []) {
+    map[r.id] = r.author?.nickname || r.author?.username || ''
+  }
+  return map
+})
 </script>
 
 <style scoped>
@@ -188,5 +204,14 @@ const canDelete = computed(
 
 .delete-btn:hover {
   color: var(--color-danger);
+}
+
+.reply-target {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+}
+
+.reply-target-name {
+  color: var(--color-primary);
 }
 </style>

--- a/frontend/src/components/common/AvatarCropDialog.vue
+++ b/frontend/src/components/common/AvatarCropDialog.vue
@@ -1,0 +1,113 @@
+<template>
+  <el-dialog
+    v-model="visible"
+    title="裁切头像"
+    width="480px"
+    :close-on-click-modal="false"
+    @closed="onClosed"
+  >
+    <div class="crop-container">
+      <img ref="imgRef" :src="imageSrc" alt="待裁切图片" class="crop-img" />
+    </div>
+    <template #footer>
+      <el-button @click="visible = false">取消</el-button>
+      <el-button type="primary" :loading="exporting" @click="handleConfirm">确认裁切</el-button>
+    </template>
+  </el-dialog>
+</template>
+
+<script setup lang="ts">
+import { ref, watch, nextTick, onBeforeUnmount } from 'vue'
+import Cropper from 'cropperjs'
+import 'cropperjs/dist/cropper.css'
+
+const props = defineProps<{
+  modelValue: boolean
+  imageSrc: string
+}>()
+
+const emit = defineEmits<{
+  'update:modelValue': [value: boolean]
+  confirm: [blob: Blob]
+}>()
+
+const visible = ref(props.modelValue)
+const imgRef = ref<HTMLImageElement | null>(null)
+const exporting = ref(false)
+let cropper: Cropper | null = null
+
+watch(
+  () => props.modelValue,
+  (val) => {
+    visible.value = val
+    if (val) {
+      nextTick(initCropper)
+    }
+  },
+)
+
+watch(visible, (val) => {
+  emit('update:modelValue', val)
+  if (!val) destroyCropper()
+})
+
+function initCropper() {
+  destroyCropper()
+  if (!imgRef.value) return
+  cropper = new Cropper(imgRef.value, {
+    aspectRatio: 1,
+    viewMode: 1,
+    dragMode: 'move',
+    autoCropArea: 0.8,
+    responsive: true,
+    cropBoxResizable: true,
+  })
+}
+
+function destroyCropper() {
+  if (cropper) {
+    cropper.destroy()
+    cropper = null
+  }
+}
+
+async function handleConfirm() {
+  if (!cropper) return
+  exporting.value = true
+  try {
+    const canvas = cropper.getCroppedCanvas({ width: 256, height: 256 })
+    canvas.toBlob(
+      (blob) => {
+        if (blob) {
+          emit('confirm', blob)
+          visible.value = false
+        }
+        exporting.value = false
+      },
+      'image/jpeg',
+      0.9,
+    )
+  } catch {
+    exporting.value = false
+  }
+}
+
+function onClosed() {
+  destroyCropper()
+}
+
+onBeforeUnmount(destroyCropper)
+</script>
+
+<style scoped>
+.crop-container {
+  width: 100%;
+  max-height: 360px;
+  overflow: hidden;
+}
+
+.crop-img {
+  display: block;
+  max-width: 100%;
+}
+</style>

--- a/frontend/src/components/common/AvatarCropDialog.vue
+++ b/frontend/src/components/common/AvatarCropDialog.vue
@@ -11,7 +11,7 @@
     </div>
     <template #footer>
       <el-button @click="visible = false">取消</el-button>
-      <el-button type="primary" :loading="exporting" @click="handleConfirm">确认裁切</el-button>
+      <el-button type="primary" :loading="exporting" @click="handleConfirm">确认</el-button>
     </template>
   </el-dialog>
 </template>
@@ -102,12 +102,12 @@ onBeforeUnmount(destroyCropper)
 <style scoped>
 .crop-container {
   width: 100%;
-  max-height: 360px;
-  overflow: hidden;
+  height: 400px;
 }
 
 .crop-img {
   display: block;
   max-width: 100%;
+  max-height: 100%;
 }
 </style>

--- a/frontend/src/views/user/ProfileView.vue
+++ b/frontend/src/views/user/ProfileView.vue
@@ -20,9 +20,14 @@
             <input
               ref="avatarInput"
               type="file"
-              accept="image/jpeg,image/png,image/gif,image/webp"
+              accept="image/jpeg,image/png,image/webp"
               style="display: none"
               @change="handleAvatarChange"
+            />
+            <AvatarCropDialog
+              v-model="showCropDialog"
+              :image-src="cropImageSrc"
+              @confirm="handleCropConfirm"
             />
             <h2>{{ user.nickname || user.username }}</h2>
             <p class="profile-username">@{{ user.username }}</p>
@@ -116,6 +121,7 @@ import { authAPI } from '@/api/auth'
 import { uploadAvatar } from '@/api/media'
 import { validatePassword } from '@/utils/validation'
 import UserAvatar from '@/components/common/UserAvatar.vue'
+import AvatarCropDialog from '@/components/common/AvatarCropDialog.vue'
 import LoadingSkeleton from '@/components/common/LoadingSkeleton.vue'
 import ErrorState from '@/components/common/ErrorState.vue'
 
@@ -147,21 +153,31 @@ const pwErrors = reactive({ old: '', new: '', confirm: '' })
 
 const avatarInput = ref<HTMLInputElement | null>(null)
 const uploadingAvatar = ref(false)
+const showCropDialog = ref(false)
+const cropImageSrc = ref('')
 
 function triggerAvatarUpload() {
   avatarInput.value?.click()
 }
 
-async function handleAvatarChange(event: Event) {
+function handleAvatarChange(event: Event) {
   const target = event.target as HTMLInputElement
   const file = target.files?.[0]
   if (!file) return
-  if (file.size > 5 * 1024 * 1024) {
-    ElMessage.error('图片大小不能超过 5MB')
+  if (file.size > 10 * 1024 * 1024) {
+    ElMessage.error('图片大小不能超过 10MB')
+    target.value = ''
     return
   }
+  cropImageSrc.value = URL.createObjectURL(file)
+  showCropDialog.value = true
+  target.value = ''
+}
+
+async function handleCropConfirm(blob: Blob) {
   uploadingAvatar.value = true
   try {
+    const file = new File([blob], 'avatar.jpg', { type: 'image/jpeg' })
     const res = await uploadAvatar(file)
     if (user.value) user.value.avatar_url = res.avatar_url
     ElMessage.success('头像更新成功')
@@ -169,7 +185,8 @@ async function handleAvatarChange(event: Event) {
     ElMessage.error('头像上传失败')
   } finally {
     uploadingAvatar.value = false
-    target.value = ''
+    URL.revokeObjectURL(cropImageSrc.value)
+    cropImageSrc.value = ''
   }
 }
 


### PR DESCRIPTION
#70 
## Summary
  - 二级评论：移除回复按钮仅限根评论的限制，所有层级均可回复；当回复目标为子评论时，评论头部显示「回复
  @username」标记
  - 头像裁切：选择头像图片后弹出裁切对话框（cropperjs，1:1 比例，输出 256×256 JPEG），确认后上传
  - 存储降级：S3 凭据未配置时自动回退到内存存储，避免开发环境启动报错

  ## Test plan
  - [ ] 对根评论和嵌套回复均可点击「回复」
  - [ ] 回复子评论时，新评论头部显示「回复 @username」
  - [ ] 头像选图后弹出裁切框，可拖动调整裁切区域
  - [ ] 确认裁切后头像更新成功，页面头像即时刷新
  - [ ] 未配置 S3 时后端正常启动，头像上传走内存存储