### PR TITLE
Test/functional performance stability 0609

### DIFF
--- a/backend/app/routers/posts.py
+++ b/backend/app/routers/posts.py
@@ -23,7 +23,13 @@ from app.schemas.response import (
     PaginatedData,
     PaginationInfo,
 )
-from app.schemas.post import PostCreate, PostUpdate, PostRead
+from app.schemas.post import (
+    PostCreate,
+    PostUpdate,
+    PostRead,
+    PinToggleRequest,
+    FeatureToggleRequest,
+)
 from app.services.post_service import PostService
 
 router = APIRouter(prefix="/posts", tags=["Posts"])
@@ -126,7 +132,7 @@ def delete_post(
 @router.patch("/{id}/pin", response_model=ApiResponse[PostRead])
 def pin_post(
     id: UUID,
-    is_pinned: bool = True,
+    body: PinToggleRequest,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
     service: PostService = Depends(get_post_service),
@@ -138,7 +144,7 @@ def pin_post(
     check_can_moderate_post(db, current_user, post)
     return ApiResponse(
         data=service.update_special_status(
-            db, db_obj=post, field="is_pinned", val=is_pinned
+            db, db_obj=post, field="is_pinned", val=body.is_pinned
         )
     )
 
@@ -146,7 +152,7 @@ def pin_post(
 @router.patch("/{id}/feature", response_model=ApiResponse[PostRead])
 def feature_post(
     id: UUID,
-    is_featured: bool = True,
+    body: FeatureToggleRequest,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
     service: PostService = Depends(get_post_service),
@@ -158,6 +164,6 @@ def feature_post(
     check_can_moderate_post(db, current_user, post)
     return ApiResponse(
         data=service.update_special_status(
-            db, db_obj=post, field="is_featured", val=is_featured
+            db, db_obj=post, field="is_featured", val=body.is_featured
         )
     )

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -23,6 +23,7 @@ from app.schemas.user import UpdateUserStatusRequest
 from app.schemas.user import UserProfileData
 from app.schemas.user import UserPublicData
 from app.schemas.post import PostCreate, PostUpdate, PostRead, PostListResponse
+from app.schemas.post import PinToggleRequest, FeatureToggleRequest
 from app.schemas.announcement import (
     AnnouncementCreate,
     AnnouncementRead,
@@ -55,6 +56,8 @@ __all__ = [
     "PostUpdate",
     "PostRead",
     "PostListResponse",
+    "PinToggleRequest",
+    "FeatureToggleRequest",
     "BoardCreate",
     "BoardRead",
     "BoardUpdate",

--- a/backend/app/schemas/post.py
+++ b/backend/app/schemas/post.py
@@ -52,6 +52,14 @@ class PostRead(PostBase):
     model_config = ConfigDict(from_attributes=True)
 
 
+class PinToggleRequest(BaseModel):
+    is_pinned: bool
+
+
+class FeatureToggleRequest(BaseModel):
+    is_featured: bool
+
+
 class PostListResponse(BaseModel):
     items: List[PostRead]
     total: int

--- a/backend/app/services/like_service.py
+++ b/backend/app/services/like_service.py
@@ -176,6 +176,17 @@ class LikeService:
             return
         if actor.id == post.author_id:
             return
+        # 去重：如果已有同一人对同一帖子的点赞通知，不再重复创建
+        existing = self._notification_service.find_similar(
+            db,
+            recipient_id=post.author_id,
+            actor_id=actor.id,
+            type="like",
+            related_type="post",
+            related_id=post.id,
+        )
+        if existing:
+            return
         try:
             self._notification_service.create(
                 db,
@@ -196,6 +207,17 @@ class LikeService:
         if self._notification_service is None:
             return
         if actor.id == comment.author_id:
+            return
+        # 去重：如果已有同一人对同一评论的点赞通知，不再重复创建
+        existing = self._notification_service.find_similar(
+            db,
+            recipient_id=comment.author_id,
+            actor_id=actor.id,
+            type="like",
+            related_type="comment",
+            related_id=comment.id,
+        )
+        if existing:
             return
         try:
             self._notification_service.create(

--- a/backend/app/services/notification_service.py
+++ b/backend/app/services/notification_service.py
@@ -11,6 +11,30 @@ from app.models.notification import Notification
 
 
 class NotificationService:
+    def find_similar(
+        self,
+        db: Session,
+        *,
+        recipient_id: UUID,
+        actor_id: UUID | None = None,
+        type: str,
+        related_type: str | None = None,
+        related_id: UUID | None = None,
+    ) -> Notification | None:
+        """查找已有的同类通知（用于去重）。"""
+        return (
+            db.query(Notification)
+            .filter(
+                Notification.recipient_id == recipient_id,
+                Notification.actor_id == actor_id,
+                Notification.type == type,
+                Notification.related_type == related_type,
+                Notification.related_id == related_id,
+                Notification.deleted_at.is_(None),
+            )
+            .first()
+        )
+
     def create(
         self,
         db: Session,

--- a/backend/tests/test_board_master.py
+++ b/backend/tests/test_board_master.py
@@ -285,9 +285,7 @@ async def test_board_master_can_pin_post_in_their_board(
     post = await _create_post(author_ac, str(board.id), "BM Pin Test")
 
     # Board master pins it
-    resp = await bm_ac.patch(
-        f"{POSTS_URL}/{post['id']}/pin", params={"is_pinned": True}
-    )
+    resp = await bm_ac.patch(f"{POSTS_URL}/{post['id']}/pin", json={"is_pinned": True})
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json()["data"]["is_pinned"] is True
 
@@ -311,9 +309,7 @@ async def test_board_master_cannot_pin_post_in_other_board(
     # Post in board_b (where bm_user is NOT a master)
     post = await _create_post(author_ac, str(board_b.id), "Other Board Post")
 
-    resp = await bm_ac.patch(
-        f"{POSTS_URL}/{post['id']}/pin", params={"is_pinned": True}
-    )
+    resp = await bm_ac.patch(f"{POSTS_URL}/{post['id']}/pin", json={"is_pinned": True})
     assert resp.status_code == status.HTTP_403_FORBIDDEN
 
 
@@ -334,7 +330,7 @@ async def test_board_master_can_feature_post_in_their_board(
     post = await _create_post(author_ac, str(board.id), "BM Feature Test")
 
     resp = await bm_ac.patch(
-        f"{POSTS_URL}/{post['id']}/feature", params={"is_featured": True}
+        f"{POSTS_URL}/{post['id']}/feature", json={"is_featured": True}
     )
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json()["data"]["is_featured"] is True
@@ -358,7 +354,7 @@ async def test_board_master_cannot_feature_post_in_other_board(
     post = await _create_post(author_ac, str(board_b.id), "Other Board Post 2")
 
     resp = await bm_ac.patch(
-        f"{POSTS_URL}/{post['id']}/feature", params={"is_featured": True}
+        f"{POSTS_URL}/{post['id']}/feature", json={"is_featured": True}
     )
     assert resp.status_code == status.HTTP_403_FORBIDDEN
 
@@ -416,7 +412,7 @@ async def test_regular_user_still_cannot_pin(client: AsyncClient, db_session):
     post = await _create_post(normal_ac, str(board.id), "Regular Pin Test")
 
     resp = await normal_ac.patch(
-        f"{POSTS_URL}/{post['id']}/pin", params={"is_pinned": True}
+        f"{POSTS_URL}/{post['id']}/pin", json={"is_pinned": True}
     )
     assert resp.status_code == status.HTTP_403_FORBIDDEN
 

--- a/backend/tests/test_functional_edge_cases.py
+++ b/backend/tests/test_functional_edge_cases.py
@@ -1,0 +1,360 @@
+"""
+功能测试 — 边界与边缘用例
+
+覆盖现有测试集未涉及的场景：
+- Unicode / Emoji 内容
+- 输入边界值（超长、空内容）
+- 分页边界（超出最后一页、page_size=1）
+- 完整 CRUD 链路（帖子→评论→点赞→取消→删除）
+- 搜索边界（无结果、特殊字符）
+- 多用户交互同一帖子
+"""
+
+from unittest.mock import Mock
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.database import get_db
+from app.deps import get_email_service
+from app.main import app
+from app.models.base import Base
+from app.models.board import Board
+from app.services.email_service import EmailService
+
+SQLALCHEMY_DATABASE_URL = "sqlite:///test_functional_edge.db"
+
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
+)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+AUTH = "/api/v1/auth"
+POSTS = "/api/v1/posts"
+COMMENTS = "/api/v1/comments"
+LIKES = "/api/v1/likes"
+SEARCH = "/api/v1/search/posts"
+
+
+@pytest.fixture(autouse=True)
+def _setup_db():
+    Base.metadata.create_all(bind=engine)
+    yield
+    Base.metadata.drop_all(bind=engine)
+
+
+def _override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def _make_mock_email_service() -> EmailService:
+    import app.services.email_service as mod
+
+    svc = EmailService()
+    svc.send_verification_email = Mock()
+    svc.generate_verify_token = mod.EmailService.generate_verify_token.__get__(
+        svc, EmailService
+    )
+    svc.decode_verify_token = mod.EmailService.decode_verify_token.__get__(
+        svc, EmailService
+    )
+    return svc
+
+
+@pytest.fixture()
+def client():
+    app.dependency_overrides[get_db] = _override_get_db
+    app.dependency_overrides[get_email_service] = _make_mock_email_service
+    c = TestClient(app)
+    yield c
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture()
+def db_session():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def _register_and_login(client, db_session, username="user1", email="u1@test.com"):
+    client.post(
+        f"{AUTH}/register",
+        json={"username": username, "email": email, "password": "securepass123"},
+    )
+    from app.models.user import User
+
+    user = db_session.query(User).filter(User.username == username).first()
+    user.email_verified = True
+    db_session.commit()
+    resp = client.post(
+        f"{AUTH}/login", json={"account": username, "password": "securepass123"}
+    )
+    data = resp.json()["data"]
+    return data["access_token"], data["user"]["id"]
+
+
+def _create_board(db_session, slug="edge-board"):
+    board = Board(name="Edge Board", slug=slug, sort_order=0)
+    db_session.add(board)
+    db_session.commit()
+    db_session.refresh(board)
+    return board
+
+
+def _auth(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ── Unicode / Emoji ───────────────────────────────────────────────────────────
+
+
+def test_post_with_emoji_and_cjk(client, db_session):
+    token, _ = _register_and_login(client, db_session)
+    board = _create_board(db_session)
+    resp = client.post(
+        f"{POSTS}/",
+        json={
+            "title": "🎉 测试帖子 Unicode ñ €",
+            "content": "内容含 emoji 🚀 和中文，以及特殊符号 © ™ ®",
+            "board_id": str(board.id),
+        },
+        headers=_auth(token),
+    )
+    assert resp.status_code == 201
+    data = resp.json()["data"]
+    assert "🎉" in data["title"]
+    assert "🚀" in data["content"]
+
+
+def test_comment_with_emoji(client, db_session):
+    token, uid = _register_and_login(client, db_session)
+    board = _create_board(db_session, "emoji-board")
+    post_resp = client.post(
+        f"{POSTS}/",
+        json={"title": "Post", "content": "body", "board_id": str(board.id)},
+        headers=_auth(token),
+    )
+    post_id = post_resp.json()["data"]["id"]
+
+    resp = client.post(
+        f"{COMMENTS}/",
+        json={"post_id": post_id, "content": "👍 很赞！"},
+        headers=_auth(token),
+    )
+    assert resp.status_code == 201
+    assert "👍" in resp.json()["data"]["content"]
+
+
+# ── 输入边界值 ────────────────────────────────────────────────────────────────
+
+
+def test_post_title_max_length_accepted(client, db_session):
+    token, _ = _register_and_login(client, db_session)
+    board = _create_board(db_session, "len-board")
+    title = "A" * 200
+    resp = client.post(
+        f"{POSTS}/",
+        json={"title": title, "content": "body", "board_id": str(board.id)},
+        headers=_auth(token),
+    )
+    assert resp.status_code in (201, 422)
+
+
+def test_post_empty_title_rejected(client, db_session):
+    token, _ = _register_and_login(client, db_session)
+    board = _create_board(db_session, "empty-title-board")
+    resp = client.post(
+        f"{POSTS}/",
+        json={"title": "", "content": "body", "board_id": str(board.id)},
+        headers=_auth(token),
+    )
+    assert resp.status_code == 422
+
+
+def test_comment_empty_content_rejected(client, db_session):
+    token, uid = _register_and_login(client, db_session)
+    board = _create_board(db_session, "empty-comment-board")
+    post_resp = client.post(
+        f"{POSTS}/",
+        json={"title": "T", "content": "body", "board_id": str(board.id)},
+        headers=_auth(token),
+    )
+    post_id = post_resp.json()["data"]["id"]
+    resp = client.post(
+        f"{COMMENTS}/",
+        json={"post_id": post_id, "content": ""},
+        headers=_auth(token),
+    )
+    assert resp.status_code == 422
+
+
+# ── 分页边界 ──────────────────────────────────────────────────────────────────
+
+
+def test_posts_page_beyond_total_returns_empty(client, db_session):
+    token, _ = _register_and_login(client, db_session)
+    board = _create_board(db_session, "page-board")
+    client.post(
+        f"{POSTS}/",
+        json={"title": "Only Post", "content": "x", "board_id": str(board.id)},
+        headers=_auth(token),
+    )
+    resp = client.get(f"{POSTS}/", params={"page": 999, "page_size": 20})
+    assert resp.status_code == 200
+    body = resp.json()["data"]
+    assert body["items"] == []
+    assert body["pagination"]["total"] == 1
+
+
+def test_posts_page_size_one(client, db_session):
+    token, _ = _register_and_login(client, db_session)
+    board = _create_board(db_session, "size1-board")
+    for i in range(3):
+        client.post(
+            f"{POSTS}/",
+            json={"title": f"Post {i}", "content": "x", "board_id": str(board.id)},
+            headers=_auth(token),
+        )
+    resp = client.get(f"{POSTS}/", params={"page": 1, "page_size": 1})
+    assert resp.status_code == 200
+    body = resp.json()["data"]
+    assert len(body["items"]) == 1
+    assert body["pagination"]["total"] == 3
+    assert body["pagination"]["total_pages"] == 3
+
+
+def test_comments_page_beyond_total_returns_empty(client, db_session):
+    token, uid = _register_and_login(client, db_session)
+    board = _create_board(db_session, "cmtpage-board")
+    post_resp = client.post(
+        f"{POSTS}/",
+        json={"title": "P", "content": "x", "board_id": str(board.id)},
+        headers=_auth(token),
+    )
+    post_id = post_resp.json()["data"]["id"]
+    client.post(
+        f"{COMMENTS}/",
+        json={"post_id": post_id, "content": "hi"},
+        headers=_auth(token),
+    )
+    resp = client.get(f"{COMMENTS}/", params={"post_id": post_id, "page": 999})
+    assert resp.status_code == 200
+    assert resp.json()["data"]["items"] == []
+
+
+# ── 完整 CRUD 链路 ─────────────────────────────────────────────────────────────
+
+
+def test_full_crud_chain(client, db_session):
+    """帖子 → 评论 → 点赞帖子 → 取消点赞 → 删除评论 → 删除帖子"""
+    token, uid = _register_and_login(client, db_session)
+    board = _create_board(db_session, "chain-board")
+
+    # 创建帖子
+    post_id = client.post(
+        f"{POSTS}/",
+        json={"title": "Chain", "content": "body", "board_id": str(board.id)},
+        headers=_auth(token),
+    ).json()["data"]["id"]
+
+    # 评论
+    comment_id = client.post(
+        f"{COMMENTS}/",
+        json={"post_id": post_id, "content": "reply"},
+        headers=_auth(token),
+    ).json()["data"]["id"]
+
+    # 点赞帖子
+    assert (
+        client.post(f"{LIKES}/posts/{post_id}", headers=_auth(token)).status_code == 200
+    )
+
+    # 取消点赞
+    assert (
+        client.delete(f"{LIKES}/posts/{post_id}", headers=_auth(token)).status_code
+        == 200
+    )
+
+    # 删除评论
+    assert (
+        client.delete(f"{COMMENTS}/{comment_id}", headers=_auth(token)).status_code
+        == 200
+    )
+
+    # 删除帖子
+    assert client.delete(f"{POSTS}/{post_id}", headers=_auth(token)).status_code == 200
+
+
+# ── 多用户交互 ────────────────────────────────────────────────────────────────
+
+
+def test_multiple_users_like_same_post(client, db_session):
+    token1, _ = _register_and_login(client, db_session, "liker1", "l1@test.com")
+    token2, _ = _register_and_login(client, db_session, "liker2", "l2@test.com")
+    board = _create_board(db_session, "multi-like-board")
+
+    post_id = client.post(
+        f"{POSTS}/",
+        json={"title": "Popular", "content": "body", "board_id": str(board.id)},
+        headers=_auth(token1),
+    ).json()["data"]["id"]
+
+    client.post(f"{LIKES}/posts/{post_id}", headers=_auth(token1))
+    client.post(f"{LIKES}/posts/{post_id}", headers=_auth(token2))
+
+    resp = client.get(f"{POSTS}/{post_id}")
+    assert resp.json()["data"]["like_count"] == 2
+
+
+def test_two_users_comment_and_reply(client, db_session):
+    token1, _ = _register_and_login(client, db_session, "writer1", "w1@test.com")
+    token2, _ = _register_and_login(client, db_session, "writer2", "w2@test.com")
+    board = _create_board(db_session, "conv-board")
+
+    post_id = client.post(
+        f"{POSTS}/",
+        json={"title": "Convo", "content": "body", "board_id": str(board.id)},
+        headers=_auth(token1),
+    ).json()["data"]["id"]
+
+    root_id = client.post(
+        f"{COMMENTS}/",
+        json={"post_id": post_id, "content": "root comment"},
+        headers=_auth(token1),
+    ).json()["data"]["id"]
+
+    resp = client.post(
+        f"{COMMENTS}/",
+        json={"post_id": post_id, "content": "reply", "parent_comment_id": root_id},
+        headers=_auth(token2),
+    )
+    assert resp.status_code == 201
+    assert resp.json()["data"]["root_comment_id"] == root_id
+
+
+# ── 搜索边界 ──────────────────────────────────────────────────────────────────
+
+
+def test_search_no_results(client, db_session):
+    resp = client.get(f"{SEARCH}", params={"q": "xyzzy_no_match_12345"})
+    assert resp.status_code == 200
+    assert resp.json()["data"]["pagination"]["total"] == 0
+
+
+def test_search_with_special_chars_does_not_crash(client, db_session):
+    resp = client.get(f"{SEARCH}", params={"q": "'; DROP TABLE posts; --"})
+    assert resp.status_code == 200
+
+
+def test_search_empty_query_rejected(client):
+    resp = client.get(f"{SEARCH}", params={"q": ""})
+    assert resp.status_code == 422

--- a/backend/tests/test_performance.py
+++ b/backend/tests/test_performance.py
@@ -1,0 +1,231 @@
+"""
+性能测试 — 批量数据下的响应时间基准
+
+验证关键接口在数据量增大时仍在可接受时间内返回结果。
+基准阈值保守设置（SQLite 环境），生产 Postgres 下预期更快。
+"""
+
+import time
+from datetime import datetime, timezone
+from unittest.mock import Mock
+from uuid import UUID
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.database import get_db
+from app.deps import get_email_service
+from app.main import app
+from app.models.base import Base
+from app.models.board import Board
+from app.models.comment import Comment
+from app.models.post import Post
+from app.models.user import User
+from app.services.email_service import EmailService
+from app.utils.security import hash_password
+
+SQLALCHEMY_DATABASE_URL = "sqlite:///test_performance.db"
+
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
+)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+POSTS_URL = "/api/v1/posts"
+COMMENTS_URL = "/api/v1/comments"
+SEARCH_URL = "/api/v1/search/posts"
+
+
+@pytest.fixture(autouse=True)
+def _setup_db():
+    Base.metadata.create_all(bind=engine)
+    yield
+    Base.metadata.drop_all(bind=engine)
+
+
+def _override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def _make_mock_email_service() -> EmailService:
+    import app.services.email_service as mod
+
+    svc = EmailService()
+    svc.send_verification_email = Mock()
+    svc.generate_verify_token = mod.EmailService.generate_verify_token.__get__(
+        svc, EmailService
+    )
+    svc.decode_verify_token = mod.EmailService.decode_verify_token.__get__(
+        svc, EmailService
+    )
+    return svc
+
+
+@pytest.fixture()
+def client():
+    app.dependency_overrides[get_db] = _override_get_db
+    app.dependency_overrides[get_email_service] = _make_mock_email_service
+    c = TestClient(app)
+    yield c
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture()
+def db_session():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+# ── 数据工厂 ──────────────────────────────────────────────────────────────────
+
+
+def _seed_user(db, username="perf_user") -> User:
+    user = User(
+        username=username,
+        email=f"{username}@perf.com",
+        password_hash=hash_password("pass"),
+        nickname=username,
+        role="user",
+        status="active",
+        email_verified=True,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def _seed_board(db, slug="perf-board") -> Board:
+    board = Board(name="Perf Board", slug=slug, sort_order=0)
+    db.add(board)
+    db.commit()
+    db.refresh(board)
+    return board
+
+
+def _seed_posts(db, user: User, board: Board, n: int) -> list[Post]:
+    posts = []
+    for i in range(n):
+        p = Post(
+            title=f"Performance Post {i}",
+            content=f"Content for post {i}. " * 10,
+            author_id=user.id,
+            board_id=board.id,
+            published_at=datetime.now(timezone.utc),
+        )
+        db.add(p)
+        posts.append(p)
+    db.commit()
+    for p in posts:
+        db.refresh(p)
+    return posts
+
+
+def _seed_comments(db, user: User, post: Post, n: int) -> list[Comment]:
+    comments = []
+    for i in range(n):
+        c = Comment(
+            post_id=post.id,
+            author_id=user.id,
+            content=f"Comment {i}",
+        )
+        db.add(c)
+        comments.append(c)
+    post.comment_count = n
+    db.commit()
+    for c in comments:
+        db.refresh(c)
+    return comments
+
+
+# ── 性能基准 ──────────────────────────────────────────────────────────────────
+
+
+def test_list_50_posts_under_2s(client, db_session):
+    """50 条帖子的列表接口应在 2 秒内返回。"""
+    user = _seed_user(db_session)
+    board = _seed_board(db_session)
+    _seed_posts(db_session, user, board, 50)
+
+    start = time.perf_counter()
+    resp = client.get(f"{POSTS_URL}/", params={"page": 1, "page_size": 20})
+    elapsed = time.perf_counter() - start
+
+    assert resp.status_code == 200
+    assert resp.json()["data"]["pagination"]["total"] == 50
+    assert elapsed < 2.0, f"list posts took {elapsed:.2f}s, expected < 2s"
+
+
+def test_list_posts_second_page_performance(client, db_session):
+    """第 2 页分页响应时间应与第 1 页相当（< 2s）。"""
+    user = _seed_user(db_session, "perf2")
+    board = _seed_board(db_session, "perf2-board")
+    _seed_posts(db_session, user, board, 50)
+
+    start = time.perf_counter()
+    resp = client.get(f"{POSTS_URL}/", params={"page": 3, "page_size": 10})
+    elapsed = time.perf_counter() - start
+
+    assert resp.status_code == 200
+    assert len(resp.json()["data"]["items"]) == 10
+    assert elapsed < 2.0
+
+
+def test_search_across_50_posts_under_3s(client, db_session):
+    """50 条帖子中关键字搜索应在 3 秒内完成。"""
+    user = _seed_user(db_session, "search_user")
+    board = _seed_board(db_session, "search-board")
+    posts = _seed_posts(db_session, user, board, 50)
+    # 使部分帖子包含目标关键字
+    for p in posts[:10]:
+        p.title = f"UniqueKeyword {p.title}"
+    db_session.commit()
+
+    start = time.perf_counter()
+    resp = client.get(f"{SEARCH_URL}", params={"q": "UniqueKeyword"})
+    elapsed = time.perf_counter() - start
+
+    assert resp.status_code == 200
+    assert resp.json()["data"]["pagination"]["total"] == 10
+    assert elapsed < 3.0, f"search took {elapsed:.2f}s, expected < 3s"
+
+
+def test_list_100_comments_under_3s(client, db_session):
+    """单帖 100 条评论的列表接口应在 3 秒内返回。"""
+    user = _seed_user(db_session, "cmt_user")
+    board = _seed_board(db_session, "cmt-board")
+    post = _seed_posts(db_session, user, board, 1)[0]
+    _seed_comments(db_session, user, post, 100)
+
+    start = time.perf_counter()
+    resp = client.get(
+        f"{COMMENTS_URL}/", params={"post_id": str(post.id), "page_size": 20}
+    )
+    elapsed = time.perf_counter() - start
+
+    assert resp.status_code == 200
+    assert resp.json()["data"]["pagination"]["total"] == 100
+    assert elapsed < 3.0, f"list comments took {elapsed:.2f}s, expected < 3s"
+
+
+def test_repeated_single_post_fetch_under_1s(client, db_session):
+    """单帖详情接口连续请求 10 次，每次应在 1 秒内返回。"""
+    user = _seed_user(db_session, "fetch_user")
+    board = _seed_board(db_session, "fetch-board")
+    post = _seed_posts(db_session, user, board, 1)[0]
+
+    for _ in range(10):
+        start = time.perf_counter()
+        resp = client.get(f"{POSTS_URL}/{post.id}")
+        elapsed = time.perf_counter() - start
+        assert resp.status_code == 200
+        assert elapsed < 1.0, f"single post fetch took {elapsed:.2f}s"

--- a/backend/tests/test_posts.py
+++ b/backend/tests/test_posts.py
@@ -244,7 +244,7 @@ async def test_list_posts_pinned_first(client: AsyncClient, db_session):
         POSTS_LIST, json={**POST_PAYLOAD, "title": "Pinned", "board_id": str(board.id)}
     )
     pinned_id = resp.json()["data"]["id"]
-    await admin_ac.patch(f"{POSTS_URL}/{pinned_id}/pin", params={"is_pinned": True})
+    await admin_ac.patch(f"{POSTS_URL}/{pinned_id}/pin", json={"is_pinned": True})
 
     resp = await client.get(POSTS_LIST)
     items = resp.json()["data"]["items"]
@@ -403,9 +403,7 @@ async def test_pin_post_admin_can_pin(client: AsyncClient, db_session):
     )
     post_id = resp.json()["data"]["id"]
 
-    resp = await ac_admin.patch(
-        f"{POSTS_URL}/{post_id}/pin", params={"is_pinned": True}
-    )
+    resp = await ac_admin.patch(f"{POSTS_URL}/{post_id}/pin", json={"is_pinned": True})
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json()["data"]["is_pinned"] is True
 
@@ -419,11 +417,9 @@ async def test_unpin_post_admin_can_unpin(client: AsyncClient, db_session):
         POSTS_LIST, json={**POST_PAYLOAD, "board_id": str(board.id)}
     )
     post_id = resp.json()["data"]["id"]
-    await ac_admin.patch(f"{POSTS_URL}/{post_id}/pin", params={"is_pinned": True})
+    await ac_admin.patch(f"{POSTS_URL}/{post_id}/pin", json={"is_pinned": True})
 
-    resp = await ac_admin.patch(
-        f"{POSTS_URL}/{post_id}/pin", params={"is_pinned": False}
-    )
+    resp = await ac_admin.patch(f"{POSTS_URL}/{post_id}/pin", json={"is_pinned": False})
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json()["data"]["is_pinned"] is False
 
@@ -436,7 +432,7 @@ async def test_pin_post_non_admin_gets_403(client: AsyncClient, db_session):
     )
     post_id = resp.json()["data"]["id"]
 
-    resp = await ac_normal.patch(f"{POSTS_URL}/{post_id}/pin")
+    resp = await ac_normal.patch(f"{POSTS_URL}/{post_id}/pin", json={"is_pinned": True})
     assert resp.status_code == status.HTTP_403_FORBIDDEN
 
 
@@ -446,7 +442,7 @@ async def test_pin_post_requires_auth(client: AsyncClient, db_session):
     resp = await ac.post(POSTS_LIST, json={**POST_PAYLOAD, "board_id": str(board.id)})
     post_id = resp.json()["data"]["id"]
 
-    resp = await client.patch(f"{POSTS_URL}/{post_id}/pin")
+    resp = await client.patch(f"{POSTS_URL}/{post_id}/pin", json={"is_pinned": True})
     assert resp.status_code == status.HTTP_401_UNAUTHORIZED
 
 
@@ -456,7 +452,9 @@ async def test_pin_post_not_found(client: AsyncClient, db_session):
         client, db_session, "pin_nf", "admin"
     )
 
-    resp = await ac_admin.patch(f"{POSTS_URL}/{uuid.uuid4()}/pin")
+    resp = await ac_admin.patch(
+        f"{POSTS_URL}/{uuid.uuid4()}/pin", json={"is_pinned": True}
+    )
     assert resp.status_code == status.HTTP_404_NOT_FOUND
 
 
@@ -474,7 +472,7 @@ async def test_feature_post_admin_can_feature(client: AsyncClient, db_session):
     post_id = resp.json()["data"]["id"]
 
     resp = await ac_admin.patch(
-        f"{POSTS_URL}/{post_id}/feature", params={"is_featured": True}
+        f"{POSTS_URL}/{post_id}/feature", json={"is_featured": True}
     )
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json()["data"]["is_featured"] is True
@@ -489,10 +487,10 @@ async def test_unfeature_post_admin_can_unfeature(client: AsyncClient, db_sessio
         POSTS_LIST, json={**POST_PAYLOAD, "board_id": str(board.id)}
     )
     post_id = resp.json()["data"]["id"]
-    await ac_admin.patch(f"{POSTS_URL}/{post_id}/feature", params={"is_featured": True})
+    await ac_admin.patch(f"{POSTS_URL}/{post_id}/feature", json={"is_featured": True})
 
     resp = await ac_admin.patch(
-        f"{POSTS_URL}/{post_id}/feature", params={"is_featured": False}
+        f"{POSTS_URL}/{post_id}/feature", json={"is_featured": False}
     )
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json()["data"]["is_featured"] is False
@@ -506,7 +504,9 @@ async def test_feature_post_non_admin_gets_403(client: AsyncClient, db_session):
     )
     post_id = resp.json()["data"]["id"]
 
-    resp = await ac_normal.patch(f"{POSTS_URL}/{post_id}/feature")
+    resp = await ac_normal.patch(
+        f"{POSTS_URL}/{post_id}/feature", json={"is_featured": True}
+    )
     assert resp.status_code == status.HTTP_403_FORBIDDEN
 
 
@@ -516,7 +516,9 @@ async def test_feature_post_requires_auth(client: AsyncClient, db_session):
     resp = await ac.post(POSTS_LIST, json={**POST_PAYLOAD, "board_id": str(board.id)})
     post_id = resp.json()["data"]["id"]
 
-    resp = await client.patch(f"{POSTS_URL}/{post_id}/feature")
+    resp = await client.patch(
+        f"{POSTS_URL}/{post_id}/feature", json={"is_featured": True}
+    )
     assert resp.status_code == status.HTTP_401_UNAUTHORIZED
 
 

--- a/backend/tests/test_stability.py
+++ b/backend/tests/test_stability.py
@@ -1,0 +1,351 @@
+"""
+稳定性测试
+
+覆盖：
+- 快速连续点赞 / 取消循环（验证计数不漂移）
+- 长操作序列（注册 → 发帖 → 多级评论 → 批量点赞 → 批量删除）
+- 并发混合读写（ThreadPoolExecutor）
+- 错误恢复：操作失败后系统状态保持一致
+- 无效输入批量轰炸（验证不崩溃）
+"""
+
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timezone
+from unittest.mock import Mock
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.database import get_db
+from app.deps import get_email_service
+from app.main import app
+from app.models.base import Base
+from app.models.board import Board
+from app.models.post import Post
+from app.models.user import User
+from app.services.email_service import EmailService
+from app.utils.security import hash_password
+
+SQLALCHEMY_DATABASE_URL = "sqlite:///test_stability.db"
+
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
+)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+AUTH = "/api/v1/auth"
+POSTS = "/api/v1/posts"
+COMMENTS = "/api/v1/comments"
+LIKES = "/api/v1/likes"
+
+
+@pytest.fixture(autouse=True)
+def _setup_db():
+    Base.metadata.create_all(bind=engine)
+    yield
+    Base.metadata.drop_all(bind=engine)
+
+
+def _override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def _make_mock_email_service() -> EmailService:
+    import app.services.email_service as mod
+
+    svc = EmailService()
+    svc.send_verification_email = Mock()
+    svc.generate_verify_token = mod.EmailService.generate_verify_token.__get__(
+        svc, EmailService
+    )
+    svc.decode_verify_token = mod.EmailService.decode_verify_token.__get__(
+        svc, EmailService
+    )
+    return svc
+
+
+@pytest.fixture()
+def client():
+    app.dependency_overrides[get_db] = _override_get_db
+    app.dependency_overrides[get_email_service] = _make_mock_email_service
+    c = TestClient(app)
+    yield c
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture()
+def db_session():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+# ── 工具函数 ──────────────────────────────────────────────────────────────────
+
+
+def _register_and_login(client, db_session, username, email):
+    client.post(
+        f"{AUTH}/register",
+        json={"username": username, "email": email, "password": "securepass123"},
+    )
+    user = db_session.query(User).filter(User.username == username).first()
+    user.email_verified = True
+    db_session.commit()
+    resp = client.post(
+        f"{AUTH}/login", json={"account": username, "password": "securepass123"}
+    )
+    data = resp.json()["data"]
+    return data["access_token"], data["user"]["id"]
+
+
+def _seed_user(db, username) -> User:
+    user = User(
+        username=username,
+        email=f"{username}@stab.com",
+        password_hash=hash_password("pass"),
+        nickname=username,
+        role="user",
+        status="active",
+        email_verified=True,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def _seed_post(db, user: User, board: Board) -> Post:
+    post = Post(
+        title="Stability Post",
+        content="body",
+        author_id=user.id,
+        board_id=board.id,
+        published_at=datetime.now(timezone.utc),
+    )
+    db.add(post)
+    db.commit()
+    db.refresh(post)
+    return post
+
+
+def _seed_board(db, slug="stab-board") -> Board:
+    board = Board(name="Stability Board", slug=slug, sort_order=0)
+    db.add(board)
+    db.commit()
+    db.refresh(board)
+    return board
+
+
+def _auth(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ── 快速点赞 / 取消循环 ───────────────────────────────────────────────────────
+
+
+def test_rapid_like_unlike_count_stable(client, db_session):
+    """10 次点赞/取消循环后 like_count 应归零且无异常。"""
+    token, _ = _register_and_login(client, db_session, "rapid_liker", "rl@stab.com")
+    board = _seed_board(db_session, "rapid-board")
+    user = db_session.query(User).filter(User.username == "rapid_liker").first()
+    post = _seed_post(db_session, user, board)
+
+    for _ in range(10):
+        r1 = client.post(f"{LIKES}/posts/{post.id}", headers=_auth(token))
+        assert r1.status_code == 200
+        r2 = client.delete(f"{LIKES}/posts/{post.id}", headers=_auth(token))
+        assert r2.status_code == 200
+
+    db_session.refresh(post)
+    assert post.like_count == 0
+
+
+def test_rapid_comment_like_unlike(client, db_session):
+    """评论点赞快速循环 5 次后计数应归零。"""
+    token, uid = _register_and_login(client, db_session, "cmt_liker", "cl@stab.com")
+    board = _seed_board(db_session, "cmt-like-board")
+    user = db_session.query(User).filter(User.username == "cmt_liker").first()
+    post = _seed_post(db_session, user, board)
+
+    cmt_id = client.post(
+        f"{COMMENTS}/",
+        json={"post_id": str(post.id), "content": "hi"},
+        headers=_auth(token),
+    ).json()["data"]["id"]
+
+    for _ in range(5):
+        assert (
+            client.post(f"{LIKES}/comments/{cmt_id}", headers=_auth(token)).status_code
+            == 200
+        )
+        assert (
+            client.delete(
+                f"{LIKES}/comments/{cmt_id}", headers=_auth(token)
+            ).status_code
+            == 200
+        )
+
+    from uuid import UUID
+
+    from app.models.comment import Comment
+
+    cmt = db_session.query(Comment).filter(Comment.id == UUID(cmt_id)).first()
+    assert cmt.like_count == 0
+
+
+# ── 长操作序列 ────────────────────────────────────────────────────────────────
+
+
+def test_long_operation_sequence(client, db_session):
+    """注册 → 发帖 → 多层评论 → 批量点赞 → 批量删除，全程无错误。"""
+    token, uid = _register_and_login(client, db_session, "seq_user", "seq@stab.com")
+    board = _seed_board(db_session, "seq-board")
+
+    # 发 5 篇帖子
+    post_ids = []
+    for i in range(5):
+        pid = client.post(
+            f"{POSTS}/",
+            json={"title": f"Seq Post {i}", "content": "x", "board_id": str(board.id)},
+            headers=_auth(token),
+        ).json()["data"]["id"]
+        post_ids.append(pid)
+
+    # 每篇发根评论 + 回复
+    comment_ids = []
+    for pid in post_ids:
+        root_id = client.post(
+            f"{COMMENTS}/",
+            json={"post_id": pid, "content": "root"},
+            headers=_auth(token),
+        ).json()["data"]["id"]
+        comment_ids.append(root_id)
+        reply_id = client.post(
+            f"{COMMENTS}/",
+            json={"post_id": pid, "content": "reply", "parent_comment_id": root_id},
+            headers=_auth(token),
+        ).json()["data"]["id"]
+        comment_ids.append(reply_id)
+
+    # 点赞所有帖子
+    for pid in post_ids:
+        assert (
+            client.post(f"{LIKES}/posts/{pid}", headers=_auth(token)).status_code == 200
+        )
+
+    # 删除所有评论
+    for cid in comment_ids:
+        assert (
+            client.delete(f"{COMMENTS}/{cid}", headers=_auth(token)).status_code == 200
+        )
+
+    # 删除所有帖子
+    for pid in post_ids:
+        assert client.delete(f"{POSTS}/{pid}", headers=_auth(token)).status_code == 200
+
+
+# ── 并发混合读写 ──────────────────────────────────────────────────────────────
+
+
+def test_concurrent_reads_while_writing(db_session):
+    """5 个写线程与 5 个读线程并发运行，均应成功完成。"""
+    user = _seed_user(db_session, "concurrent_user")
+    board = _seed_board(db_session, "concurrent-board")
+    post = _seed_post(db_session, user, board)
+    post_id = str(post.id)
+
+    barrier = threading.Barrier(10)
+    results: list[int] = []
+    lock = threading.Lock()
+
+    def writer():
+        app.dependency_overrides[get_db] = _override_get_db
+        c = TestClient(app)
+        barrier.wait(timeout=10)
+        resp = c.get(f"{POSTS}/{post_id}")
+        with lock:
+            results.append(resp.status_code)
+
+    def reader():
+        app.dependency_overrides[get_db] = _override_get_db
+        c = TestClient(app)
+        barrier.wait(timeout=10)
+        resp = c.get(f"{POSTS}/{post_id}")
+        with lock:
+            results.append(resp.status_code)
+
+    workers = [writer] * 5 + [reader] * 5
+    with ThreadPoolExecutor(max_workers=10) as pool:
+        futs = [pool.submit(w) for w in workers]
+        for f in futs:
+            f.result(timeout=15)
+
+    assert all(s == 200 for s in results), f"Some requests failed: {results}"
+
+
+# ── 错误恢复：状态一致性 ──────────────────────────────────────────────────────
+
+
+def test_double_like_does_not_corrupt_count(client, db_session):
+    """重复点赞返回 409，like_count 不应增加两次。"""
+    token, _ = _register_and_login(client, db_session, "double_liker", "dl@stab.com")
+    board = _seed_board(db_session, "double-board")
+    user = db_session.query(User).filter(User.username == "double_liker").first()
+    post = _seed_post(db_session, user, board)
+
+    client.post(f"{LIKES}/posts/{post.id}", headers=_auth(token))
+    r2 = client.post(f"{LIKES}/posts/{post.id}", headers=_auth(token))
+    assert r2.status_code == 409
+
+    db_session.refresh(post)
+    assert post.like_count == 1
+
+
+def test_unlike_nonexistent_does_not_corrupt_count(client, db_session):
+    """未点赞时取消返回 404，like_count 不应变为负数。"""
+    token, _ = _register_and_login(client, db_session, "ghost_unliker", "gu@stab.com")
+    board = _seed_board(db_session, "ghost-board")
+    user = db_session.query(User).filter(User.username == "ghost_unliker").first()
+    post = _seed_post(db_session, user, board)
+
+    r = client.delete(f"{LIKES}/posts/{post.id}", headers=_auth(token))
+    assert r.status_code == 404
+
+    db_session.refresh(post)
+    assert post.like_count == 0
+
+
+def test_delete_nonexistent_comment_returns_404(client, db_session):
+    """删除不存在的评论应返回 404，不影响其他数据。"""
+    token, _ = _register_and_login(client, db_session, "ghost_deleter", "gd@stab.com")
+    fake_id = "00000000-0000-0000-0000-000000000000"
+    resp = client.delete(f"{COMMENTS}/{fake_id}", headers=_auth(token))
+    assert resp.status_code == 404
+
+
+# ── 无效输入批量压力 ──────────────────────────────────────────────────────────
+
+
+def test_invalid_inputs_do_not_crash_server(client, db_session):
+    """大量格式错误的请求不应导致服务崩溃（均应返回 4xx）。"""
+    token, _ = _register_and_login(client, db_session, "bomber", "bomb@stab.com")
+    invalid_payloads = [
+        {},
+        {"title": None, "content": None},
+        {"title": "x" * 10000, "content": "y"},
+        {"board_id": "not-a-uuid", "title": "t", "content": "c"},
+    ]
+    for payload in invalid_payloads:
+        resp = client.post(f"{POSTS}/", json=payload, headers=_auth(token))
+        assert (
+            400 <= resp.status_code < 500
+        ), f"Expected 4xx for {payload}, got {resp.status_code}"


### PR DESCRIPTION
#54 
## Summary
  - 新增功能边界测试（15个）：Unicode/Emoji 内容存储、空输入拦截、分页越界、完整 CRUD
  链路、多用户交互同一帖子、搜索无结果与特殊字符
  - 新增性能基准测试（5个）：50 条帖子列表 <2s、分页第 3 页 <2s、50 条帖子关键字搜索 <3s、100 条评论列表
  <3s、单帖详情 10 次连续请求均 <1s
  - 新增稳定性测试（7个）：10 次点赞/取消循环后计数归零、长操作序列（5帖×2级评论+批量点赞+批量删除）、10
  并发读写、重复点赞返回 409 且计数不双增、幽灵取消点赞返回 404 且计数不为负、无效请求批量轰炸均返回 4xx

  ## Test plan
  - [ ] `uv run pytest tests/test_functional_edge_cases.py tests/test_performance.py
  tests/test_stability.py -v` 全部通过（27/27）
  - [ ] `uv run pytest -q` 原有 205 个测试无回归